### PR TITLE
add APPLICATION_COMMAND_* events

### DIFF
--- a/src/gateway/handlers/applicationCommandCreate.ts
+++ b/src/gateway/handlers/applicationCommandCreate.ts
@@ -1,0 +1,15 @@
+import { SlashCommand } from '../../models/slashClient.ts'
+import { ApplicationCommandPayload } from '../../types/gateway.ts'
+import { Gateway, GatewayEventHandler } from '../index.ts'
+
+export const applicationCommandCreate: GatewayEventHandler = async (
+  gateway: Gateway,
+  d: ApplicationCommandPayload
+) => {
+  const guild =
+    d.guild_id === undefined
+      ? undefined
+      : await gateway.client.guilds.get(d.guild_id)
+  const cmd = new SlashCommand(gateway.client.slash.commands, d, guild)
+  gateway.client.emit('slashCommandCreate', cmd)
+}

--- a/src/gateway/handlers/applicationCommandDelete.ts
+++ b/src/gateway/handlers/applicationCommandDelete.ts
@@ -1,0 +1,15 @@
+import { SlashCommand } from '../../models/slashClient.ts'
+import { ApplicationCommandPayload } from '../../types/gateway.ts'
+import { Gateway, GatewayEventHandler } from '../index.ts'
+
+export const applicationCommandDelete: GatewayEventHandler = async (
+  gateway: Gateway,
+  d: ApplicationCommandPayload
+) => {
+  const guild =
+    d.guild_id === undefined
+      ? undefined
+      : await gateway.client.guilds.get(d.guild_id)
+  const cmd = new SlashCommand(gateway.client.slash.commands, d, guild)
+  gateway.client.emit('slashCommandDelete', cmd)
+}

--- a/src/gateway/handlers/applicationCommandUpdate.ts
+++ b/src/gateway/handlers/applicationCommandUpdate.ts
@@ -1,0 +1,15 @@
+import { SlashCommand } from '../../models/slashClient.ts'
+import { ApplicationCommandPayload } from '../../types/gateway.ts'
+import { Gateway, GatewayEventHandler } from '../index.ts'
+
+export const applicationCommandUpdate: GatewayEventHandler = async (
+  gateway: Gateway,
+  d: ApplicationCommandPayload
+) => {
+  const guild =
+    d.guild_id === undefined
+      ? undefined
+      : await gateway.client.guilds.get(d.guild_id)
+  const cmd = new SlashCommand(gateway.client.slash.commands, d, guild)
+  gateway.client.emit('slashCommandUpdate', cmd)
+}

--- a/src/gateway/handlers/index.ts
+++ b/src/gateway/handlers/index.ts
@@ -63,11 +63,18 @@ import { CommandContext } from '../../models/command.ts'
 import { RequestMethods } from '../../models/rest.ts'
 import { PartialInvitePayload } from '../../types/invite.ts'
 import { GuildChannels } from '../../types/guild.ts'
+import { applicationCommandCreate } from './applicationCommandCreate.ts'
+import { applicationCommandDelete } from './applicationCommandDelete.ts'
+import { applicationCommandUpdate } from './applicationCommandUpdate.ts'
+import { SlashCommand } from '../../models/slashClient.ts'
 
 export const gatewayHandlers: {
   [eventCode in GatewayEvents]: GatewayEventHandler | undefined
 } = {
   READY: ready,
+  APPLICATION_COMMAND_CREATE: applicationCommandCreate,
+  APPLICATION_COMMAND_DELETE: applicationCommandDelete,
+  APPLICATION_COMMAND_UPDATE: applicationCommandUpdate,
   RECONNECT: reconnect,
   RESUMED: resume,
   CHANNEL_CREATE: channelCreate,
@@ -394,7 +401,9 @@ export type ClientEvents = {
   guildMemberUpdateUncached: [member: Member]
   guildMemberRemoveUncached: [member: Member]
   channelUpdateUncached: [channel: GuildChannels]
-
+  slashCommandCreate: [cmd: SlashCommand]
+  slashCommandUpdate: [cmd: SlashCommand]
+  slashCommandDelete: [cmd: SlashCommand]
   commandOwnerOnly: [ctx: CommandContext]
   commandGuildOnly: [ctx: CommandContext]
   commandDmOnly: [ctx: CommandContext]

--- a/src/gateway/handlers/ready.ts
+++ b/src/gateway/handlers/ready.ts
@@ -8,6 +8,12 @@ export const ready: GatewayEventHandler = async (
   d: Ready
 ) => {
   gateway.client.upSince = new Date()
+
+  if ('application' in d) {
+    gateway.client.applicationID = d.application.id
+    gateway.client.applicationFlags = d.application.flags
+  }
+
   await gateway.client.guilds.flush()
 
   await gateway.client.users.set(d.user.id, d.user)

--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -154,6 +154,9 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
     return this.shards.list.get('0') as Gateway
   }
 
+  applicationID?: string
+  applicationFlags?: number
+
   constructor(options: ClientOptions = {}) {
     super()
     this._id = options.id

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -11,6 +11,7 @@ import {
   ClientStatus
 } from './presence.ts'
 import { RolePayload } from './role.ts'
+import { SlashCommandPayload } from './slash.ts'
 import { UserPayload } from './user.ts'
 
 /**
@@ -106,7 +107,10 @@ export enum GatewayEvents {
   Voice_Server_Update = 'VOICE_SERVER_UPDATE',
   Voice_State_Update = 'VOICE_STATE_UPDATE',
   Webhooks_Update = 'WEBHOOKS_UPDATE',
-  Interaction_Create = 'INTERACTION_CREATE'
+  Interaction_Create = 'INTERACTION_CREATE',
+  Application_Command_Create = 'APPLICATION_COMMAND_CREATE',
+  Application_Command_Update = 'APPLICATION_COMMAND_UPDATE',
+  Application_Command_Delete = 'APPLICATION_COMMAND_DELETE'
 }
 
 export interface IdentityPayload {
@@ -168,6 +172,7 @@ export interface Ready {
   guilds: []
   session_id: string
   shard?: number[]
+  application: { id: string; flags: number }
 }
 
 export interface ChannelPinsUpdatePayload {
@@ -343,4 +348,8 @@ export interface TypingStartPayload {
 export interface TypingStartGuildData {
   guild: Guild
   member: Member
+}
+
+export interface ApplicationCommandPayload extends SlashCommandPayload {
+  guild_id?: string
 }


### PR DESCRIPTION
## About

literally title, though, adds following new events:
- `slashCommandCreate`
- `slashCommandUpdate`
- `slashCommandDelete`

ref: https://github.com/discord/discord-api-docs/pull/2367

## Status

- [x] These changes have been tested against Discord API or contain no API change.
