### PR TITLE
fix(models/rest): unique key for form data item

### DIFF
--- a/src/models/rest.ts
+++ b/src/models/rest.ts
@@ -319,7 +319,7 @@ export class RESTManager {
         }
       }
       const form = new FormData()
-      files.map((file, index) => form.append(`file${index + 1}`, file.blob, file.name))
+      files.forEach((file, index) => form.append(`file${index + 1}`, file.blob, file.name))
       const json = JSON.stringify(body)
       form.append('payload_json', json)
       if (body === undefined) body = {}

--- a/src/models/rest.ts
+++ b/src/models/rest.ts
@@ -319,9 +319,7 @@ export class RESTManager {
         }
       }
       const form = new FormData()
-      for (const file of files) {
-        form.append(file.name, file.blob, file.name)
-      }
+      files.map((file, index) => form.append(`file${index + 1}`, file.blob, file.name))
       const json = JSON.stringify(body)
       form.append('payload_json', json)
       if (body === undefined) body = {}


### PR DESCRIPTION
## About
The name of the files may not be unique at all times, there occurs an instance where the name of the file may be the same; however, Discord will not regard the second item of the form data if any two items have the same key.
<!-- describe what changes does this PR introduce and why are these needed -->

## Status

- [ ] These changes have been tested against Discord API or contain no API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
