### PR TITLE
Use a fork of Denoflate to have cache-able WASM

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,5 @@
 export { EventEmitter } from 'https://deno.land/x/event@0.2.1/mod.ts'
-export { unzlib } from 'https://deno.land/x/denoflate@1.1/mod.ts'
+export { unzlib } from 'https://raw.githubusercontent.com/DjDeveloperr/denoflate/master/mod.ts'
 export { fetchAuto } from 'https://raw.githubusercontent.com/DjDeveloperr/fetch-base64/main/mod.ts'
 export { parse } from 'https://deno.land/x/mutil@0.1.2/mod.ts'
 export { connect } from 'https://deno.land/x/redis@v0.14.1/mod.ts'

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -169,7 +169,10 @@ client.on('messageCreate', async (msg: Message) => {
     )
   } else if (msg.content === '!textfile') {
     msg.channel.send({
-      file: new MessageAttachment('hello.txt', 'hello world')
+      files: [
+        new MessageAttachment('hello.txt', 'world'),
+        new MessageAttachment('world.txt', 'hello')
+      ]
     })
   } else if (msg.content === '!join') {
     if (msg.member === undefined) return


### PR DESCRIPTION
I've updated deps.ts to use my fork of denoflate instead of the original one which downloads WASM each time Harmony code is run.. which is.. lol.