### PR TITLE
fix(BitField): resolve the bit before checking

### DIFF
--- a/src/utils/bitfield.ts
+++ b/src/utils/bitfield.ts
@@ -27,7 +27,7 @@ export class BitField {
 
   has(bit: BitFieldResolvable, ...args: any[]): boolean {
     if (Array.isArray(bit)) return (bit.every as any)((p: any) => this.has(p))
-    bit = BitField.resolve(this.flags, bit);
+    bit = BitField.resolve(this.flags, bit)
     return (this.bitfield & bit) === bit
   }
 

--- a/src/utils/bitfield.ts
+++ b/src/utils/bitfield.ts
@@ -27,7 +27,8 @@ export class BitField {
 
   has(bit: BitFieldResolvable, ...args: any[]): boolean {
     if (Array.isArray(bit)) return (bit.every as any)((p: any) => this.has(p))
-    return (this.bitfield & BitField.resolve(this.flags, bit)) === bit
+    bit = BitField.resolve(this.flags, bit);
+    return (this.bitfield & bit) === bit
   }
 
   missing(bits: any, ...hasParams: any[]): string[] {


### PR DESCRIPTION
## About

Passing a `string` or `string[]` as a resolvable to `BitField.has()` would not resolve the bit coming in for comparison, which means it would always return `false`. Porting [this missing line from Discord.JS](https://github.com/discordjs/discord.js/blob/master/src/util/BitField.js#L45) (which is all this PR does) should fix the issue.

## Status

- [x] These changes have been tested against Discord API or contain no API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
