### PR TITLE
Fix Client#connect()'s logic to prioritize the token parameter over Client#token

### DIFF
--- a/src/models/client.ts
+++ b/src/models/client.ts
@@ -291,10 +291,9 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
    * @param intents Gateway intents in array. This is required if not given in ClientOptions.
    */
   async connect(token?: string, intents?: GatewayIntents[]): Promise<Client> {
-    if (token === undefined && this.token !== undefined) token = this.token
-    else if (this.token === undefined && token !== undefined) {
-      this.token = token
-    } else throw new Error('No Token Provided')
+    token ??= this.token
+    if (token === undefined) throw new Error('No Token Provided')
+    this.token = token
     if (intents !== undefined && this.intents !== undefined) {
       this.debug(
         'client',


### PR DESCRIPTION
## About

When `Client#token` was set and the token parameter was passed to `Client#connect()`, the module would throw an 'No Token Provided' error.
This change makes this function prioritize the parameter over `Client#token`.

## Status

- [x] These changes have been tested against Discord API or contain no API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
