### PR TITLE
fix slash commands in deploy

### DIFF
--- a/deploy.ts
+++ b/deploy.ts
@@ -75,6 +75,8 @@ export function handle(
   client.handle(cmd, handler)
 }
 
+// Hacky workaround. Timers don't exist in Deploy runtime, what a shame!
+
 if (typeof (window as any).setTimeout !== 'function') {
   Object.defineProperty(window, 'setTimeout', {
     value: (fn: CallableFunction, _ms: number, ...args: any[]) => {

--- a/deploy.ts
+++ b/deploy.ts
@@ -75,6 +75,21 @@ export function handle(
   client.handle(cmd, handler)
 }
 
+if (typeof (window as any).setTimeout !== 'function') {
+  Object.defineProperty(window, 'setTimeout', {
+    value: (fn: CallableFunction, _ms: number, ...args: any[]) => {
+      fn(...args)
+      return 0
+    }
+  })
+}
+
+if (typeof (window as any).clearTimeout !== 'function') {
+  Object.defineProperty(window, 'clearTimeout', {
+    value: (_id: number) => {}
+  })
+}
+
 export { commands, client }
 export * from './src/types/slash.ts'
 export * from './src/structures/slash.ts'

--- a/deploy.ts
+++ b/deploy.ts
@@ -75,7 +75,7 @@ export function handle(
   client.handle(cmd, handler)
 }
 
-// Hacky workaround. Timers don't exist in Deploy runtime, what a shame!
+// Hacky workaround. Timers don't exist in Deploy runtime :(
 
 if (typeof (window as any).setTimeout !== 'function') {
   Object.defineProperty(window, 'setTimeout', {


### PR DESCRIPTION
There being no timers in Deploy runtime, REST doesn't work at all. For now, I added a check if they don't exist add dummy functions. Better than it not starting up in Deploy at all.