### PR TITLE
FIX(command) incorrect value for rest default value

### DIFF
--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -103,5 +103,5 @@ function parseRest(
 ): void {
   const restValues = argsNullable.filter((x) => typeof x === 'string')
   args[entry.name] =
-    restValues !== null ? restValues?.join(' ') : entry.defaultValue
+    restValues.length > 0 ? restValues?.join(' ') : entry.defaultValue
 }

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -148,3 +148,27 @@ Deno.test({
   sanitizeResources: true,
   sanitizeExit: true
 })
+
+const messageArgs5: string[] = ['<@!708544768342229012>']
+const expectedResult5 = {
+  user: '708544768342229012',
+  reason: 'No reason provided'
+}
+const commandArgs5: Args[] = [
+  {
+    name: 'user',
+    match: 'mentionUser'
+  },
+  {
+    name: 'reason',
+    match: 'rest',
+    defaultValue: 'No reason provided'
+  }
+]
+Deno.test({
+  name: 'parse command arguments, rest match default',
+  fn: () => {
+    const result = parseArgs(commandArgs5, messageArgs5)
+    assertEquals(result, expectedResult5)
+  }
+})


### PR DESCRIPTION
## About

Fixes cases like this where no rest value is provided but it doesn't use `defaultValue`
```ts
const messageArgs5: string[] = ['<@!708544768342229012>']
const expectedResult5 = {
  user: '708544768342229012',
  reason: 'No reason provided'
}
const commandArgs5: Args[] = [
  {
    name: 'user',
    match: 'mentionUser'
  },
  {
    name: 'reason',
    match: 'rest',
    defaultValue: 'No reason provided'
  }
]
```

Added a test for it aswell

## Status

- [x] These changes have been tested against Discord API or contain no API change.
