### PR TITLE
Add filter function to `match: "content"`

### DIFF
--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -33,7 +33,7 @@ interface Content extends ArgsBase {
 
 interface Rest extends ArgsBase {
   match: 'rest'
-  defaultValue?: any
+  defaultValue?: string
 }
 
 export type Args = Flag | Mention | Content | Rest
@@ -41,11 +41,11 @@ export type Args = Flag | Mention | Content | Rest
 export function parseArgs(
   commandArgs: Args[] | undefined,
   messageArgs: string[]
-): Record<string, unknown> | null {
+): Record<string, string | number | boolean> | null {
   if (commandArgs === undefined) return null
 
   const messageArgsNullableCopy: Array<string | null> = [...messageArgs]
-  const args: Record<string, unknown> = {}
+  const args: Record<string, string | number | boolean> = {}
 
   for (const entry of commandArgs) {
     switch (entry.match) {

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -11,32 +11,37 @@ const mentionToRegex: MentionToRegex = {
   mentionChannel: /<#(\d{17,19})>/
 }
 
-interface ArgsBase {
+interface ArgumentBase {
   name: string
 }
 
-interface Flag extends ArgsBase {
+export interface FlagArgument extends ArgumentBase {
   match: 'flag'
   flag: string
   defaultValue?: boolean
 }
 
-interface Mention extends ArgsBase {
+export interface MentionArgument extends ArgumentBase {
   match: 'mentionUser' | 'mentionRole' | 'mentionChannel'
   defaultValue?: string
 }
-interface Content extends ArgsBase {
+
+export interface ContentArgument extends ArgumentBase {
   match: 'content'
   defaultValue?: string | number
   contentFilter?: (value: string, index: number, array: string[]) => boolean
 }
 
-interface Rest extends ArgsBase {
+export interface RestArgument extends ArgumentBase {
   match: 'rest'
   defaultValue?: string
 }
 
-export type Args = Flag | Mention | Content | Rest
+export type Args =
+  | FlagArgument
+  | MentionArgument
+  | ContentArgument
+  | RestArgument
 
 export function parseArgs(
   commandArgs: Args[] | undefined,
@@ -70,7 +75,7 @@ export function parseArgs(
 
 function parseFlags(
   args: Record<string, unknown>,
-  entry: Flag,
+  entry: FlagArgument,
   argsNullable: Array<string | null>
 ): void {
   for (let i = 0; i < argsNullable.length; i++) {
@@ -84,7 +89,7 @@ function parseFlags(
 
 function parseMention(
   args: Record<string, unknown>,
-  entry: Mention,
+  entry: MentionArgument,
   argsNullable: Array<string | null>
 ): void {
   const regex = mentionToRegex[entry.match]
@@ -101,7 +106,7 @@ function parseMention(
 
 function parseContent(
   args: Record<string, unknown>,
-  entry: Content,
+  entry: ContentArgument,
   argsNonNullable: string[]
 ): void {
   args[entry.name] =
@@ -114,7 +119,7 @@ function parseContent(
 
 function parseRest(
   args: Record<string, unknown>,
-  entry: Rest,
+  entry: RestArgument,
   argsNullable: Array<string | null>
 ): void {
   const restValues = argsNullable.filter((x) => typeof x === 'string')

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -1,8 +1,5 @@
 import { Args, parseArgs } from '../src/utils/command.ts'
-import {
-  assertEquals,
-  assertNotEquals
-} from './deps.ts'
+import { assertEquals, assertNotEquals } from './deps.ts'
 
 const commandArgs: Args[] = [
   {
@@ -173,7 +170,6 @@ Deno.test({
   }
 })
 
-
 const messageArgs6: string[] = ['get', '<@!708544768342229012>']
 const expectedResult6 = {
   user: '708544768342229012',
@@ -188,7 +184,7 @@ const commandArgs6: Args[] = [
     name: 'subcommand',
     match: 'content',
     defaultValue: 'random',
-    contentFilter: ((x: string) => x === "get")
+    contentFilter: (x: string) => x === 'get'
   }
 ]
 

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -2,7 +2,7 @@ import { Args, parseArgs } from '../src/utils/command.ts'
 import {
   assertEquals,
   assertNotEquals
-} from 'https://deno.land/std@0.95.0/testing/asserts.ts'
+} from './deps.ts'
 
 const commandArgs: Args[] = [
   {
@@ -170,5 +170,32 @@ Deno.test({
   fn: () => {
     const result = parseArgs(commandArgs5, messageArgs5)
     assertEquals(result, expectedResult5)
+  }
+})
+
+
+const messageArgs6: string[] = ['get', '<@!708544768342229012>']
+const expectedResult6 = {
+  user: '708544768342229012',
+  subcommand: ['get']
+}
+const commandArgs6: Args[] = [
+  {
+    name: 'user',
+    match: 'mentionUser'
+  },
+  {
+    name: 'subcommand',
+    match: 'content',
+    defaultValue: 'random',
+    contentFilter: ((x: string) => x === "get")
+  }
+]
+
+Deno.test({
+  name: 'parse command arguments, match content filter',
+  fn: () => {
+    const result = parseArgs(commandArgs6, messageArgs6)
+    assertEquals(result, expectedResult6)
   }
 })


### PR DESCRIPTION
## About

Add filter function for match type content

## Status

- [x] These changes have been tested against Discord API or contain no API change.
