### PR TITLE
id support for args

### DIFF
--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -6,9 +6,9 @@ interface MentionToRegex {
 }
 
 const mentionToRegex: MentionToRegex = {
-  mentionUser: /<@!?(\d{17,19})>/,
-  mentionRole: /<@&(\d{17,19})>/,
-  mentionChannel: /<#(\d{17,19})>/
+  mentionUser: /<@!?(\d{17,19})>|(\d{17,19})/,
+  mentionRole: /<@&(\d{17,19})>|(\d{17,19})/,
+  mentionChannel: /<#(\d{17,19})>|(\d{17,19})/
 }
 
 export type CommandArgumentMatchTypes =

--- a/src/utils/command.ts
+++ b/src/utils/command.ts
@@ -6,16 +6,16 @@ interface MentionToRegex {
 }
 
 const mentionToRegex: MentionToRegex = {
-  mentionUser: /<@!?(\d{17,19})>|(\d{17,19})/,
-  mentionRole: /<@&(\d{17,19})>|(\d{17,19})/,
-  mentionChannel: /<#(\d{17,19})>|(\d{17,19})/
+  user: /<@!?(\d{17,19})>|(\d{17,19})/,
+  mention: /<@&(\d{17,19})>|(\d{17,19})/,
+  channel: /<#(\d{17,19})>|(\d{17,19})/
 }
 
 export type CommandArgumentMatchTypes =
   | 'flag'
-  | 'mentionUser'
-  | 'mentionRole'
-  | 'mentionChannel'
+  | 'user'
+  | 'role'
+  | 'channel'
   | 'content'
   | 'rest'
 
@@ -40,9 +40,9 @@ export function parseArgs(
       case 'flag':
         parseFlags(args, entry, messageArgsNullableCopy)
         break
-      case 'mentionUser':
-      case 'mentionRole':
-      case 'mentionChannel':
+      case 'user':
+      case 'role':
+      case 'channel':
         parseMention(args, entry, messageArgsNullableCopy)
         break
       case 'content':

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -174,13 +174,13 @@ Deno.test({
 })
 
 // only ID testing
-const messageArgs6: string[] = [
+const messageArgs7: string[] = [
   '708544768342229012',
   'bye',
   '783319033730564098',
   '836715188690092032'
 ]
-const expectedResult6 = {
+const expectedResult7 = {
   channel: '783319033730564098',
   role: '836715188690092032',
   user: '708544768342229012',
@@ -189,8 +189,8 @@ const expectedResult6 = {
 Deno.test({
   name: 'parse command arguments with ID\'s (assertEquals)',
   fn: () => {
-    const result = parseArgs(commandArgs2, messageArgs6)
-    assertEquals(result, expectedResult6)
+    const result = parseArgs(commandArgs2, messageArgs7)
+    assertEquals(result, expectedResult7)
   },
   sanitizeOps: true,
   sanitizeResources: true,

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -113,7 +113,7 @@ const commandArgs2: Args[] = [
   },
   {
     name: 'role',
-    match: 'channel'
+    match: 'role'
   },
   {
     name: 'reason',

--- a/test/argsparser_test.ts
+++ b/test/argsparser_test.ts
@@ -17,7 +17,7 @@ const commandArgs: Args[] = [
   },
   {
     name: 'user',
-    match: 'mentionUser'
+    match: 'user'
   },
   {
     name: 'reason',
@@ -108,15 +108,15 @@ Deno.test({
 const commandArgs2: Args[] = [
   {
     name: 'user',
-    match: 'mentionUser'
+    match: 'user'
   },
   {
     name: 'channel',
-    match: 'mentionChannel'
+    match: 'channel'
   },
   {
     name: 'role',
-    match: 'mentionRole'
+    match: 'channel'
   },
   {
     name: 'reason',
@@ -157,7 +157,7 @@ const expectedResult5 = {
 const commandArgs5: Args[] = [
   {
     name: 'user',
-    match: 'mentionUser'
+    match: 'user'
   },
   {
     name: 'reason',
@@ -171,4 +171,28 @@ Deno.test({
     const result = parseArgs(commandArgs5, messageArgs5)
     assertEquals(result, expectedResult5)
   }
+})
+
+// only ID testing
+const messageArgs6: string[] = [
+  '708544768342229012',
+  'bye',
+  '783319033730564098',
+  '836715188690092032'
+]
+const expectedResult6 = {
+  channel: '783319033730564098',
+  role: '836715188690092032',
+  user: '708544768342229012',
+  reason: 'bye'
+}
+Deno.test({
+  name: 'parse command arguments with ID\'s (assertEquals)',
+  fn: () => {
+    const result = parseArgs(commandArgs2, messageArgs6)
+    assertEquals(result, expectedResult6)
+  },
+  sanitizeOps: true,
+  sanitizeResources: true,
+  sanitizeExit: true
 })


### PR DESCRIPTION
## About

adds ID parsing support for args
i don't know what i'm doing
One thing I think should be added as well but I thought was too breaking for some people's code was changing mentionX to just X (eg: mentionUser -> user)

## Status

- [ ] These changes have been tested against Discord API or contain no API change.
- [ ] This PR includes only documentation changes, no code change.
- [possible] This PR introduces some Breaking changes.
