### PR TITLE
feat: change ready event logic

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -429,7 +429,7 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
       recipient_id: id
     })
     await this.channels.set(dmPayload.id, dmPayload)
-    return (this.channels.get<DMChannel>(dmPayload.id) as unknown) as DMChannel
+    return this.channels.get<DMChannel>(dmPayload.id) as unknown as DMChannel
   }
 
   /** Returns a template object for the given code. */
@@ -448,9 +448,11 @@ export function event(name?: keyof ClientEvents) {
   ) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const c = client as any
-    const listener = ((client as unknown) as {
-      [name in keyof ClientEvents]: (...args: ClientEvents[name]) => any
-    })[(prop as unknown) as keyof ClientEvents]
+    const listener = (
+      client as unknown as {
+        [name in keyof ClientEvents]: (...args: ClientEvents[name]) => any
+      }
+    )[prop as unknown as keyof ClientEvents]
     if (typeof listener !== 'function')
       throw new Error('@event decorator requires a function')
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -309,6 +309,7 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
     token?: string,
     intents?: Array<GatewayIntents | keyof typeof GatewayIntents>
   ): Promise<Client> {
+    await this.guilds.flush()
     token ??= this.token
     if (token === undefined) throw new Error('No Token Provided')
     this.token = token

--- a/src/client/shard.ts
+++ b/src/client/shard.ts
@@ -107,7 +107,7 @@ export class ShardManager extends HarmonyEventEmitter<ShardManagerEvents> {
       this.emit('shardDisconnect', id, code, reason)
     )
 
-    return gw.waitFor(GatewayEvents.Ready, () => true).then(() => this)
+    return gw.waitFor('guildsLoaded', () => true).then(() => this)
   }
 
   /** Launches all Shards */
@@ -118,7 +118,9 @@ export class ShardManager extends HarmonyEventEmitter<ShardManagerEvents> {
     const startTime = Date.now()
     for (let i = 0; i < shardCount; i++) {
       await this.launch(i)
+      this.client.emit('guildsLoaded', i)
     }
+    this.client.emit('ready', shardCount)
     const endTime = Date.now()
     const diff = endTime - startTime
     this.debug(

--- a/src/gateway/handlers/guildCreate.ts
+++ b/src/gateway/handlers/guildCreate.ts
@@ -9,7 +9,7 @@ export const guildCreate: GatewayEventHandler = async (
 ) => {
   const hasGuild: Guild | undefined = await gateway.client.guilds.get(d.id)
   await gateway.client.guilds.set(d.id, d)
-  const guild = ((await gateway.client.guilds.get(d.id)) as unknown) as Guild
+  const guild = (await gateway.client.guilds.get(d.id)) as unknown as Guild
 
   if (d.members !== undefined) await guild.members.fromPayload(d.members)
 
@@ -35,5 +35,11 @@ export const guildCreate: GatewayEventHandler = async (
   if (hasGuild === undefined) {
     // It wasn't lazy load, so emit event
     gateway.client.emit('guildCreate', guild)
-  } else gateway.client.emit('guildLoaded', guild)
+  } else {
+    if (gateway._guildsLoaded !== undefined) {
+      gateway._guildsLoaded++
+      gateway._checkGuildsLoaded()
+    }
+    gateway.client.emit('guildLoaded', guild)
+  }
 }

--- a/src/gateway/handlers/guildDelete.ts
+++ b/src/gateway/handlers/guildDelete.ts
@@ -6,7 +6,17 @@ export const guildDelete: GatewayEventHandler = async (
   gateway: Gateway,
   d: GuildPayload
 ) => {
+  // It will be removed anyway if its deleted
+  await gateway.client.guilds.set(d.id, d)
   const guild: Guild | undefined = await gateway.client.guilds.get(d.id)
+  if ('unavailable' in d) {
+    if (gateway._guildsLoaded !== undefined) {
+      gateway._guildsLoaded++
+      gateway._checkGuildsLoaded()
+    }
+    gateway.client.emit('guildUnavailable', guild)
+    return
+  }
 
   if (guild !== undefined) {
     await guild.members.flush()

--- a/src/gateway/handlers/mod.ts
+++ b/src/gateway/handlers/mod.ts
@@ -126,7 +126,11 @@ export interface VoiceServerUpdateData {
 // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type ClientEvents = {
   /** When Client has successfully connected to Discord */
-  ready: [shard: number]
+  ready: [shards: number]
+  /** When a Shard has recieved READY */
+  shardReady: [shard: number]
+  /** When all guilds of a Shard are loaded */
+  guildsLoaded: [shard: number]
   /** When a reconnect was requested by Discord */
   reconnect: [shard: number]
   /** When a successful session resume has been done */
@@ -248,6 +252,7 @@ export type ClientEvents = {
    * @param after Guild object after update
    */
   guildUpdate: [before: Guild, after: Guild]
+  guildUnavailable: [guild: Guild]
   /**
    * A new Message was created (sent)
    * @param message The new Message object
@@ -377,7 +382,7 @@ export type ClientEvents = {
    * @param evt Event name string
    * @param payload Payload JSON of the event
    */
-  raw: [evt: string, payload: any]
+  raw: [evt: string, payload: any, shard: number]
 
   /**
    * An uncached Message was deleted.

--- a/src/gateway/mod.ts
+++ b/src/gateway/mod.ts
@@ -44,6 +44,7 @@ export type GatewayTypedEvents = {
   sentIdentify: []
   sentResume: []
   reconnecting: []
+  guildsLoaded: []
   init: []
 }
 
@@ -67,6 +68,9 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
   private timedIdentify: number | null = null
   shards?: number[]
   ping: number = 0
+
+  _guildsToBeLoaded?: number
+  _guildsLoaded?: number
 
   constructor(client: Client, shards?: number[]) {
     super()
@@ -152,7 +156,13 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
           const handler = gatewayHandlers[t]
 
           if (handler !== undefined && d !== null) {
-            handler(this, d)
+            try {
+              handler(this, d)
+            } catch (e) {
+              console.log(
+                `Internal error in Shard ${this.shards?.[0] ?? 0}: ${e}`
+              )
+            }
           }
         }
         break
@@ -177,6 +187,19 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
       }
       default:
         break
+    }
+  }
+
+  _checkGuildsLoaded(): void {
+    if (
+      this._guildsLoaded !== undefined &&
+      this._guildsToBeLoaded !== undefined
+    ) {
+      if (this._guildsLoaded >= this._guildsToBeLoaded) {
+        this.emit('guildsLoaded')
+        this._guildsLoaded = undefined
+        this._guildsToBeLoaded = undefined
+      }
     }
   }
 
@@ -386,7 +409,7 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
   }
 
   debug(msg: string): void {
-    this.client.debug('Gateway', msg)
+    this.client.debug(`Shard ${this.shards?.[0] ?? 0}`, msg)
   }
 
   async reconnect(forceNew?: boolean): Promise<void> {

--- a/src/gateway/mod.ts
+++ b/src/gateway/mod.ts
@@ -151,7 +151,7 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
         }
         if (t !== null && t !== undefined) {
           this.emit(t as any, d)
-          this.client.emit('raw', t, d)
+          this.client.emit('raw', t, d, this.shards?.[0] ?? 0)
 
           const handler = gatewayHandlers[t]
 

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -197,7 +197,7 @@ export class Guild extends SnowflakeBase {
   constructor(client: Client, data: GuildPayload) {
     super(client, data)
     this.id = data.id
-    this.unavailable = data.unavailable
+    this.unavailable = data.unavailable ?? false
     this.readFromData(data)
     this.bans = new GuildBans(client, this)
     this.members = new MembersManager(this.client, this)

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -3,7 +3,7 @@
 import type { Guild } from '../structures/guild.ts'
 import type { Member } from '../structures/member.ts'
 import type { EmojiPayload } from './emoji.ts'
-import type { MemberPayload } from './guild.ts'
+import type { GuildPayload, MemberPayload } from './guild.ts'
 import type {
   ActivityGame,
   ActivityPayload,
@@ -169,7 +169,7 @@ export interface Ready {
   v: number
   user: UserPayload
   privateChannels: []
-  guilds: []
+  guilds: GuildPayload[]
   session_id: string
   shard?: number[]
   application: { id: string; flags: number }

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -53,7 +53,7 @@ export interface GuildPayload {
   rules_channel_id?: string
   joined_at?: string
   large?: boolean
-  unavailable: boolean
+  unavailable?: boolean
   member_count?: number
   voice_states?: VoiceStatePayload[]
   members?: MemberPayload[]


### PR DESCRIPTION
This PR changes how `ready` works.
Current `ready` was just when shard received READY, but now it waits for all guilds to be loaded first.
Previous ready is now available in `shardReady` event instead.
Also fixes a bug where ready flushed guilds loaded by other shards..