### PR TITLE
fix(client) Race condition

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -309,6 +309,7 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
     token?: string,
     intents?: Array<GatewayIntents | keyof typeof GatewayIntents>
   ): Promise<Client> {
+    const readyPromise = this.waitFor('ready', () => true);
     await this.guilds.flush()
     token ??= this.token
     if (token === undefined) throw new Error('No Token Provided')
@@ -332,7 +333,8 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
         this.shards.cachedShardCount = this.shardCount
       await this.shards.launch(this.shard)
     } else await this.shards.connect()
-    return this.waitFor('ready', () => true).then(() => this)
+    await readyPromise
+    return this
   }
 
   /** Destroy the Gateway connection */


### PR DESCRIPTION
## About
This pr fixes a race condition where `ready` event is already dispatched but client adds the listener after the event is fired.
because if this we are waiting for an event that does not get fire under normal circumstances

## Status

- [x] These changes have been tested against Discord API or contain no API change.
