### PR TITLE
feat: optimize cache

### DIFF
--- a/src/cache/adapter.ts
+++ b/src/cache/adapter.ts
@@ -12,11 +12,20 @@ export interface ICacheAdapter {
     key: string,
     value: any,
     expire?: number
-  ) => Promise<any> | any
+  ) => Promise<void> | void
   /** Deletes a key from a Cache */
-  delete: (cacheName: string, key: string) => Promise<boolean> | boolean
+  delete: (cacheName: string, ...keys: string[]) => Promise<boolean> | boolean
   /** Gets array of all values in a Cache */
   array: (cacheName: string) => undefined | any[] | Promise<any[] | undefined>
   /** Entirely deletes a Cache */
-  deleteCache: (cacheName: string) => any
+  deleteCache: (cacheName: string) => boolean | Promise<boolean>
+  /** Get size (length) of entries in a Cache */
+  size: (
+    cacheName: string,
+    filter?: (payload: any) => boolean
+  ) => number | undefined | Promise<number | undefined>
+  /** Gets all keys of the Cache */
+  keys: (
+    cacheName: string
+  ) => string[] | undefined | Promise<string[] | undefined>
 }

--- a/src/cache/default.ts
+++ b/src/cache/default.ts
@@ -7,9 +7,7 @@ export class DefaultCacheAdapter implements ICacheAdapter {
   data = new Map<string, Collection<string, any>>()
 
   get(cacheName: string, key: string): any {
-    const cache = this.data.get(cacheName)
-    if (cache === undefined) return
-    return cache.get(key)
+    return this.data.get(cacheName)?.get(key)
   }
 
   set(cacheName: string, key: string, value: any, expire?: number): void {
@@ -36,9 +34,7 @@ export class DefaultCacheAdapter implements ICacheAdapter {
   }
 
   array(cacheName: string): any[] | undefined {
-    const cache = this.data.get(cacheName)
-    if (cache === undefined) return
-    return cache.array()
+    return this.data.get(cacheName)?.array()
   }
 
   deleteCache(cacheName: string): boolean {

--- a/src/cache/default.ts
+++ b/src/cache/default.ts
@@ -3,48 +3,61 @@ import type { ICacheAdapter } from './adapter.ts'
 
 /** Default Cache Adapter for in-memory caching. */
 export class DefaultCacheAdapter implements ICacheAdapter {
-  data: {
-    [name: string]: Collection<string, any>
-  } = {}
+  // we're using Map here because we don't utilize Collection's methods
+  data = new Map<string, Collection<string, any>>()
 
-  async get(cacheName: string, key: string): Promise<undefined | any> {
-    const cache = this.data[cacheName]
+  get(cacheName: string, key: string): any {
+    const cache = this.data.get(cacheName)
     if (cache === undefined) return
     return cache.get(key)
   }
 
-  async set(
-    cacheName: string,
-    key: string,
-    value: any,
-    expire?: number
-  ): Promise<any> {
-    let cache = this.data[cacheName]
+  set(cacheName: string, key: string, value: any, expire?: number): void {
+    let cache = this.data.get(cacheName)
     if (cache === undefined) {
-      this.data[cacheName] = new Collection()
-      cache = this.data[cacheName]
+      cache = new Collection()
+      this.data.set(cacheName, cache)
     }
     cache.set(key, value)
     if (expire !== undefined)
       setTimeout(() => {
-        cache.delete(key)
+        cache?.delete(key)
       }, expire)
   }
 
-  async delete(cacheName: string, key: string): Promise<boolean> {
-    const cache = this.data[cacheName]
+  delete(cacheName: string, ...keys: string[]): boolean {
+    const cache = this.data.get(cacheName)
     if (cache === undefined) return false
-    return cache.delete(key)
+    let deleted = true
+    for (const key of keys) {
+      if (cache.delete(key) === false) deleted = false
+    }
+    return deleted
   }
 
-  async array(cacheName: string): Promise<any[] | undefined> {
-    const cache = this.data[cacheName]
+  array(cacheName: string): any[] | undefined {
+    const cache = this.data.get(cacheName)
     if (cache === undefined) return
     return cache.array()
   }
 
-  async deleteCache(cacheName: string): Promise<boolean> {
+  deleteCache(cacheName: string): boolean {
     // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-    return delete this.data[cacheName]
+    return this.data.delete(cacheName)
+  }
+
+  size(
+    cacheName: string,
+    filter?: (payload: any) => boolean
+  ): number | undefined {
+    const cache = this.data.get(cacheName)
+    if (cache === undefined) return
+    return filter !== undefined ? cache.filter(filter).size : cache.size
+  }
+
+  keys(cacheName: string): string[] | undefined {
+    const cache = this.data.get(cacheName)
+    if (cache === undefined) return
+    return [...cache.keys()]
   }
 }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -68,7 +68,7 @@ export interface ClientOptions {
   shard?: number
   /** ADVACNED: Shard count. */
   shardCount?: number | 'auto'
-  /** Whether to enable Zlib Compression or not (enabled by default) */
+  /** Whether to enable Zlib Compression (for Gateway) or not (enabled by default) */
   compress?: boolean
   /** Max number of messages to cache per channel. Default 100 */
   messageCacheMax?: number
@@ -155,7 +155,7 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
   /** Collectors set */
   collectors: Set<Collector> = new Set()
 
-  /** Whether Zlib compression is enabled or not */
+  /** Whether Zlib compression (for Gateway) is enabled or not */
   compress = true
 
   /** Since when is Client online (ready). */

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -68,6 +68,10 @@ export interface ClientOptions {
   shard?: number
   /** ADVACNED: Shard count. */
   shardCount?: number | 'auto'
+  /** Whether to enable Zlib Compression or not (enabled by default) */
+  compress?: boolean
+  /** Max number of messages to cache per channel. Default 100 */
+  messageCacheMax?: number
 }
 
 /**
@@ -107,6 +111,8 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
   forceNewSession?: boolean
   /** Time till messages to stay cached, in MS. */
   messageCacheLifetime: number = 3600000
+  /** Max number of messages to cache per channel. Default 100 */
+  messageCacheMax: number = 100
   /** Time till messages to stay cached, in MS. */
   reactionCacheLifetime: number = 3600000
   /** Whether to fetch Uncached Message of Reaction or not? */
@@ -149,6 +155,9 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
   /** Collectors set */
   collectors: Set<Collector> = new Set()
 
+  /** Whether Zlib compression is enabled or not */
+  compress = true
+
   /** Since when is Client online (ready). */
   get uptime(): number {
     if (this.upSince === undefined) return 0
@@ -188,6 +197,9 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
       this.reactionCacheLifetime = options.reactionCacheLifetime
     if (options.fetchUncachedReactions === true)
       this.fetchUncachedReactions = true
+    if (options.messageCacheMax !== undefined)
+      this.messageCacheMax = options.messageCacheMax
+    if (options.compress !== undefined) this.compress = options.compress
 
     if (
       (this as any)._decoratedEvents !== undefined &&
@@ -309,7 +321,7 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
     token?: string,
     intents?: Array<GatewayIntents | keyof typeof GatewayIntents>
   ): Promise<Client> {
-    const readyPromise = this.waitFor('ready', () => true);
+    const readyPromise = this.waitFor('ready', () => true)
     await this.guilds.flush()
     token ??= this.token
     if (token === undefined) throw new Error('No Token Provided')

--- a/src/gateway/handlers/guildBanAdd.ts
+++ b/src/gateway/handlers/guildBanAdd.ts
@@ -1,16 +1,14 @@
 import type { Gateway, GatewayEventHandler } from '../mod.ts'
 import { Guild } from '../../structures/guild.ts'
-import { User } from '../../structures/user.ts'
 import { GuildBanAddPayload } from '../../types/gateway.ts'
 
 export const guildBanAdd: GatewayEventHandler = async (
   gateway: Gateway,
   d: GuildBanAddPayload
 ) => {
+  await gateway.client.users.set(d.user.id, d.user)
   const guild: Guild | undefined = await gateway.client.guilds.get(d.guild_id)
-  const user: User =
-    (await gateway.client.users.get(d.user.id)) ??
-    new User(gateway.client, d.user)
+  const user = (await gateway.client.users.get(d.user.id))!
 
   if (guild !== undefined) {
     // We don't have to delete member, already done with guildMemberRemove event

--- a/src/gateway/handlers/guildBanRemove.ts
+++ b/src/gateway/handlers/guildBanRemove.ts
@@ -1,6 +1,5 @@
 import type { Gateway, GatewayEventHandler } from '../mod.ts'
 import { Guild } from '../../structures/guild.ts'
-import { User } from '../../structures/user.ts'
 import { GuildBanRemovePayload } from '../../types/gateway.ts'
 
 export const guildBanRemove: GatewayEventHandler = async (
@@ -8,9 +7,8 @@ export const guildBanRemove: GatewayEventHandler = async (
   d: GuildBanRemovePayload
 ) => {
   const guild: Guild | undefined = await gateway.client.guilds.get(d.guild_id)
-  const user: User =
-    (await gateway.client.users.get(d.user.id)) ??
-    new User(gateway.client, d.user)
+  await gateway.client.users.set(d.user.id, d.user)
+  const user = (await gateway.client.users.get(d.user.id))!
 
   if (guild !== undefined) {
     gateway.client.emit('guildBanRemove', guild, user)

--- a/src/gateway/handlers/guildCreate.ts
+++ b/src/gateway/handlers/guildCreate.ts
@@ -29,6 +29,9 @@ export const guildCreate: GatewayEventHandler = async (
 
   for (const emojiPayload of d.emojis) {
     if (emojiPayload.id === null) continue
+    if (emojiPayload.user !== undefined) {
+      await gateway.client.users.set(emojiPayload.user.id, emojiPayload.user)
+    }
     await gateway.client.emojis.set(emojiPayload.id, emojiPayload)
   }
 

--- a/src/gateway/handlers/guildEmojiUpdate.ts
+++ b/src/gateway/handlers/guildEmojiUpdate.ts
@@ -17,6 +17,8 @@ export const guildEmojiUpdate: GatewayEventHandler = async (
     const _updated: EmojiPayload[] = []
 
     for (const raw of d.emojis) {
+      if (raw.user !== undefined)
+        await gateway.client.users.set(raw.user.id, raw.user)
       const emojiID = (raw.id !== null ? raw.id : raw.name) as string
       const has = emojis.get(emojiID)
       if (has === undefined) {

--- a/src/gateway/handlers/guildMemberAdd.ts
+++ b/src/gateway/handlers/guildMemberAdd.ts
@@ -1,7 +1,6 @@
 import type { Gateway, GatewayEventHandler } from '../mod.ts'
 import { Guild } from '../../structures/guild.ts'
 import { GuildMemberAddPayload } from '../../types/gateway.ts'
-import { Member } from '../../structures/member.ts'
 
 export const guildMemberAdd: GatewayEventHandler = async (
   gateway: Gateway,
@@ -12,6 +11,6 @@ export const guildMemberAdd: GatewayEventHandler = async (
   if (guild === undefined) return
 
   await guild.members.set(d.user.id, d)
-  const member = (await guild.members.get(d.user.id)) as Member
+  const member = (await guild.members.get(d.user.id))!
   gateway.client.emit('guildMemberAdd', member)
 }

--- a/src/gateway/handlers/guildMemberRemove.ts
+++ b/src/gateway/handlers/guildMemberRemove.ts
@@ -11,6 +11,7 @@ export const guildMemberRemove: GatewayEventHandler = async (
   // Weird case, shouldn't happen
   if (guild === undefined) return
 
+  await gateway.client.users.set(d.user.id, d.user)
   const member = await guild.members.get(d.user.id)
   await guild.members._delete(d.user.id)
 

--- a/src/gateway/handlers/guildMemberUpdate.ts
+++ b/src/gateway/handlers/guildMemberUpdate.ts
@@ -12,6 +12,7 @@ export const guildMemberUpdate: GatewayEventHandler = async (
   // Weird case, shouldn't happen
   if (guild === undefined) return
 
+  await gateway.client.users.set(d.user.id, d.user)
   const member = await guild.members.get(d.user.id)
   const newMemberPayload: MemberPayload = {
     user: d.user,

--- a/src/gateway/handlers/messageReactionAdd.ts
+++ b/src/gateway/handlers/messageReactionAdd.ts
@@ -37,14 +37,14 @@ export const messageReactionAdd: GatewayEventHandler = async (
       emoji: d.emoji,
       me: d.user_id === gateway.client.user?.id
     })
-    reaction = ((await message.reactions.get(
+    reaction = (await message.reactions.get(
       emojiID
-    )) as unknown) as MessageReaction
+    )) as unknown as MessageReaction
   }
 
-  const rawUser = ((await gateway.client.users.get(
+  const rawUser = (await gateway.client.users.get(
     d.user_id
-  )) as unknown) as UserPayload
+  )) as unknown as UserPayload
 
   reaction.users.set(rawUser.id, rawUser)
 

--- a/src/gateway/handlers/messageUpdate.ts
+++ b/src/gateway/handlers/messageUpdate.ts
@@ -23,6 +23,6 @@ export const messageUpdate: GatewayEventHandler = async (
   Object.assign(newRaw, d)
   await channel.messages.set(d.id, newRaw)
 
-  const newMsg = ((await channel.messages.get(d.id)) as unknown) as Message
+  const newMsg = (await channel.messages.get(d.id)) as unknown as Message
   gateway.client.emit('messageUpdate', message, newMsg)
 }

--- a/src/gateway/handlers/presenceUpdate.ts
+++ b/src/gateway/handlers/presenceUpdate.ts
@@ -8,6 +8,7 @@ export const presenceUpdate: GatewayEventHandler = async (
   const guild = await gateway.client.guilds.get(d.guild_id)
   if (guild === undefined) return
 
+  await gateway.client.users.set(d.user.id, d.user)
   await guild.presences.set(d.user.id, d)
   const presence = await guild.presences.get(d.user.id)
   if (presence === undefined) return

--- a/src/gateway/mod.ts
+++ b/src/gateway/mod.ts
@@ -330,7 +330,7 @@ export class Gateway extends HarmonyEventEmitter<GatewayTypedEvents> {
         $browser: this.client.clientProperties.browser ?? 'harmony',
         $device: this.client.clientProperties.device ?? 'harmony'
       },
-      compress: true,
+      compress: this.client.compress,
       shard:
         this.shards === undefined
           ? [0, 1]

--- a/src/interactions/slashCommand.ts
+++ b/src/interactions/slashCommand.ts
@@ -114,7 +114,8 @@ function createSlashOption(
     name: data.name,
     type,
     description:
-      type === 0 || type === 1
+      type === SlashCommandOptionType.SUB_COMMAND ||
+      type === SlashCommandOptionType.SUB_COMMAND_GROUP
         ? undefined
         : data.description ?? 'No description.',
     options: data.options?.map((e) =>

--- a/src/managers/base.ts
+++ b/src/managers/base.ts
@@ -88,6 +88,11 @@ export class BaseManager<T, T2> extends Base {
     return this.client.cache.deleteCache(this.cacheName)
   }
 
+  /** Gets number of values stored in Cache */
+  async size(): Promise<number> {
+    return (await this.client.cache.size(this.cacheName)) ?? 0
+  }
+
   [Deno.customInspect](): string {
     return `Manager(${this.cacheName})`
   }

--- a/src/managers/baseChild.ts
+++ b/src/managers/baseChild.ts
@@ -63,6 +63,11 @@ export class BaseChildManager<T, T2> extends Base {
     }
   }
 
+  /** Gets number of values stored in Cache */
+  async size(): Promise<number> {
+    return this.parent.size()
+  }
+
   [Deno.customInspect](): string {
     return `ChildManager(${this.parent.cacheName})`
   }

--- a/src/managers/channels.ts
+++ b/src/managers/channels.ts
@@ -205,4 +205,20 @@ export class ChannelsManager extends BaseManager<ChannelPayload, Channel> {
     await res.mentions.fromPayload(newMsg)
     return res
   }
+
+  /** Get cache size for messages. Returns total messages cache size if channel param is not given */
+  async messageCacheSize(channel?: string | TextChannel): Promise<number> {
+    if (channel === undefined) {
+      const channels = (await this.client.cache.keys('channels')) ?? []
+      if (channels.length === 0) return 0
+      let size = 0
+      for (const id of channels) {
+        size += await this.messageCacheSize(id)
+      }
+      return size
+    }
+
+    const id = typeof channel === 'object' ? channel.id : channel
+    return (await this.client.cache.size(`messages:${id}`)) ?? 0
+  }
 }

--- a/src/managers/guildChannelVoiceStates.ts
+++ b/src/managers/guildChannelVoiceStates.ts
@@ -26,6 +26,15 @@ export class GuildChannelVoiceStatesManager extends BaseChildManager<
     else return undefined
   }
 
+  async size(): Promise<number> {
+    return (
+      (await this.client.cache.size(
+        this.parent.cacheName,
+        (d) => d.channel_id === this.channel.id
+      )) ?? 0
+    )
+  }
+
   async array(): Promise<VoiceState[]> {
     const arr = (await this.parent.array()) as VoiceState[]
     return arr.filter((c: any) => c.channel?.id === this.channel.id) as any

--- a/src/managers/guildChannels.ts
+++ b/src/managers/guildChannels.ts
@@ -42,6 +42,15 @@ export class GuildChannelsManager extends BaseChildManager<
     else return undefined
   }
 
+  async size(): Promise<number> {
+    return (
+      (await this.client.cache.size(
+        this.parent.cacheName,
+        (d) => d.guild_id === this.guild.id
+      )) ?? 0
+    )
+  }
+
   /** Delete a Guild Channel */
   async delete(id: string): Promise<boolean> {
     return this.client.rest.delete(CHANNEL(id))
@@ -66,7 +75,7 @@ export class GuildChannelsManager extends BaseChildManager<
   async create(options: CreateChannelOptions): Promise<GuildChannels> {
     if (options.name === undefined)
       throw new Error('name is required for GuildChannelsManager#create')
-    const res = ((await this.client.rest.post(GUILD_CHANNELS(this.guild.id), {
+    const res = (await this.client.rest.post(GUILD_CHANNELS(this.guild.id), {
       name: options.name,
       type: options.type,
       topic: options.topic,
@@ -82,11 +91,11 @@ export class GuildChannelsManager extends BaseChildManager<
           ? options.parent.id
           : options.parent,
       nsfw: options.nsfw
-    })) as unknown) as GuildChannelPayload
+    })) as unknown as GuildChannelPayload
 
     await this.set(res.id, res)
     const channel = await this.get(res.id)
-    return (channel as unknown) as GuildChannels
+    return channel as unknown as GuildChannels
   }
 
   /** Modify the positions of a set of channel positions for the guild. */

--- a/src/managers/guildEmojis.ts
+++ b/src/managers/guildEmojis.ts
@@ -22,6 +22,15 @@ export class GuildEmojisManager extends BaseChildManager<EmojiPayload, Emoji> {
     else return undefined
   }
 
+  async size(): Promise<number> {
+    return (
+      (await this.client.cache.size(
+        this.parent.cacheName,
+        (d) => d.guild_id === this.guild.id
+      )) ?? 0
+    )
+  }
+
   async delete(id: string): Promise<boolean> {
     return this.client.rest.delete(CHANNEL(id))
   }

--- a/src/managers/guilds.ts
+++ b/src/managers/guilds.ts
@@ -250,4 +250,20 @@ export class GuildManager extends BaseManager<GuildPayload, Guild> {
     await this.client.rest.delete(GUILD(guild))
     return oldGuild
   }
+
+  /** Returns number of entries in Members Cache. Returns total of all guilds if guild param is not given */
+  async memberCacheSize(guild?: string | Guild): Promise<number> {
+    if (guild === undefined) {
+      const guilds = (await this.client.cache.keys('guilds')) ?? []
+      if (guilds.length === 0) return 0
+      let size = 0
+      for (const id of guilds) {
+        size += await this.memberCacheSize(id)
+      }
+      return size
+    }
+
+    const id = typeof guild === 'object' ? guild.id : guild
+    return (await this.client.cache.size(`members:${id}`)) ?? 0
+  }
 }

--- a/src/managers/memberRoles.ts
+++ b/src/managers/memberRoles.ts
@@ -42,7 +42,7 @@ export class MemberRolesManager extends BaseChildManager<RolePayload, Role> {
   async size(): Promise<number> {
     const payload = await this.member.guild.members._get(this.member.id)
     if (payload === undefined) return 0
-    else return payload.roles.length
+    return payload.roles.length
   }
 
   async array(): Promise<Role[]> {

--- a/src/managers/memberRoles.ts
+++ b/src/managers/memberRoles.ts
@@ -39,6 +39,12 @@ export class MemberRolesManager extends BaseChildManager<RolePayload, Role> {
     else return undefined
   }
 
+  async size(): Promise<number> {
+    const payload = await this.member.guild.members._get(this.member.id)
+    if (payload === undefined) return 0
+    else return payload.roles.length
+  }
+
   async array(): Promise<Role[]> {
     const arr = (await this.parent.array()) as Role[]
     const mem = await this._resolveMemberPayload()

--- a/src/managers/members.ts
+++ b/src/managers/members.ts
@@ -6,6 +6,7 @@ import { GUILD_MEMBER } from '../types/endpoint.ts'
 import type { MemberPayload } from '../types/guild.ts'
 import { BaseManager } from './base.ts'
 import { Permissions } from '../utils/permissions.ts'
+import { UserPayload } from '../types/user.ts'
 
 export class MembersManager extends BaseManager<MemberPayload, Member> {
   guild: Guild
@@ -18,7 +19,7 @@ export class MembersManager extends BaseManager<MemberPayload, Member> {
   async get(key: string): Promise<Member | undefined> {
     const raw = await this._get(key)
     if (raw === undefined) return
-    const user = new User(this.client, raw.user)
+    const user = (await this.client.users.get(raw.user.id))! // it will always be present, see `set` impl for details
     const roles = await this.guild.roles.array()
     let permissions = new Permissions(Permissions.DEFAULT)
     if (roles !== undefined) {
@@ -35,6 +36,15 @@ export class MembersManager extends BaseManager<MemberPayload, Member> {
       permissions
     )
     return res
+  }
+
+  async set(id: string, payload: MemberPayload): Promise<void> {
+    await this.client.users.set(payload.user.id, payload.user)
+    // to prevent duplication of user object we'll store it in user cache
+    // and only keep id here for retreiving later from user cache
+    payload = { ...payload }
+    payload.user = { id: payload.user.id } as unknown as UserPayload
+    await super.set(id, payload)
   }
 
   async array(): Promise<Member[]> {
@@ -103,16 +113,14 @@ export class MembersManager extends BaseManager<MemberPayload, Member> {
             let permissions = new Permissions(Permissions.DEFAULT)
             if (roles !== undefined) {
               const mRoles = roles.filter(
-                (r) => (member.roles.includes(r.id) as boolean) || r.id === this.guild.id
+                (r) =>
+                  (member.roles.includes(r.id) as boolean) ||
+                  r.id === this.guild.id
               )
               permissions = new Permissions(mRoles.map((r) => r.permissions))
-              members.push(new Member(
-                this.client,
-                member, 
-                user,
-                this.guild,
-                permissions
-              ))
+              members.push(
+                new Member(this.client, member, user, this.guild, permissions)
+              )
             }
           }
 
@@ -137,16 +145,14 @@ export class MembersManager extends BaseManager<MemberPayload, Member> {
             let permissions = new Permissions(Permissions.DEFAULT)
             if (roles !== undefined) {
               const mRoles = roles.filter(
-                (r) => (member.roles.includes(r.id) as boolean) || r.id === this.guild.id
+                (r) =>
+                  (member.roles.includes(r.id) as boolean) ||
+                  r.id === this.guild.id
               )
               permissions = new Permissions(mRoles.map((r) => r.permissions))
-              members.push(new Member(
-                this.client,
-                member, 
-                user,
-                this.guild,
-                permissions
-              ))
+              members.push(
+                new Member(this.client, member, user, this.guild, permissions)
+              )
             }
           }
 

--- a/src/managers/messages.ts
+++ b/src/managers/messages.ts
@@ -34,7 +34,7 @@ export class MessagesManager extends BaseManager<MessagePayload, Message> {
     return res
   }
 
-  async set(key: string, value: MessagePayload): Promise<any> {
+  async set(key: string, value: MessagePayload): Promise<void> {
     await this.client.cache.set(
       this.cacheName,
       key,

--- a/src/managers/messages.ts
+++ b/src/managers/messages.ts
@@ -4,13 +4,14 @@ import type { TextChannel } from '../structures/textChannel.ts'
 import { User } from '../structures/user.ts'
 import type { MessagePayload } from '../types/channel.ts'
 import { CHANNEL_MESSAGE } from '../types/endpoint.ts'
+import { Snowflake } from '../utils/snowflake.ts'
 import { BaseManager } from './base.ts'
 
 export class MessagesManager extends BaseManager<MessagePayload, Message> {
   channel: TextChannel
 
   constructor(client: Client, channel: TextChannel) {
-    super(client, 'messages', Message)
+    super(client, `messages:${channel.id}`, Message)
     this.channel = channel
   }
 
@@ -24,24 +25,30 @@ export class MessagesManager extends BaseManager<MessagePayload, Message> {
     if (channel === undefined)
       channel = await this.client.channels.fetch(raw.channel_id)
 
-    let author = ((await this.client.users.get(
-      raw.author.id
-    )) as unknown) as User
+    let author = (await this.client.users.get(raw.author.id)) as unknown as User
 
     if (author === undefined) author = new User(this.client, raw.author)
 
-    const res = new this.DataType(this.client, raw, channel, author) as any
+    const res = new this.DataType(this.client, raw, channel, author)
     await res.mentions.fromPayload(raw)
     return res
   }
 
   async set(key: string, value: MessagePayload): Promise<any> {
-    return this.client.cache.set(
+    await this.client.cache.set(
       this.cacheName,
       key,
       value,
       this.client.messageCacheLifetime
     )
+    const keys = (await this.client.cache.keys(this.cacheName)) ?? []
+    if (keys.length > this.client.messageCacheMax) {
+      const sorted = keys.sort(
+        (b, a) => new Snowflake(a).timestamp - new Snowflake(b).timestamp
+      )
+      const toRemove = sorted.filter((_, i) => i >= this.client.messageCacheMax)
+      await this.client.cache.delete(this.cacheName, ...toRemove)
+    }
   }
 
   async array(): Promise<Message[]> {
@@ -60,9 +67,9 @@ export class MessagesManager extends BaseManager<MessagePayload, Message> {
           channel = await this.client.channels.fetch(raw.channel_id)
         if (channel === undefined) return
 
-        let author = ((await this.client.users.get(
+        let author = (await this.client.users.get(
           raw.author.id
-        )) as unknown) as User
+        )) as unknown as User
 
         if (author === undefined) author = new User(this.client, raw.author)
 

--- a/src/managers/presences.ts
+++ b/src/managers/presences.ts
@@ -3,6 +3,7 @@ import type { Guild } from '../structures/guild.ts'
 import { Presence } from '../structures/presence.ts'
 import { User } from '../structures/user.ts'
 import type { PresenceUpdatePayload } from '../types/gateway.ts'
+import { UserPayload } from '../types/user.ts'
 import { BaseManager } from './base.ts'
 
 export class GuildPresencesManager extends BaseManager<
@@ -25,6 +26,14 @@ export class GuildPresencesManager extends BaseManager<
     if (guild === undefined) return
     const presence = new Presence(this.client, raw, user, guild)
     return presence
+  }
+
+  async set(id: string, payload: PresenceUpdatePayload): Promise<void> {
+    await this.client.users.set(payload.user.id, payload.user)
+    // see Members Manager's set method for more info
+    payload = { ...payload }
+    payload.user = { id: payload.user.id } as unknown as UserPayload
+    await super.set(id, payload)
   }
 
   async array(): Promise<Presence[]> {


### PR DESCRIPTION
- adds optimized .size methods to managers and child managers
- adds .memberCacheSize to GuildsManager and .messageCacheSize to ChannelsManager
- fixes user not being cached from member object and duplication of user object in member objects
- added per channel message cache limit and corresponding option
- added option to disable compression

there are some breaking changes for cache adapter too, though

tested bot on 300 guilds
before: 100mb+ usage
now: 20mb~ usage