### PR TITLE
Fix #178 Interaction.send() throws if passed a string

### DIFF
--- a/src/structures/interactions.ts
+++ b/src/structures/interactions.ts
@@ -311,9 +311,9 @@ export class Interaction extends SnowflakeBase {
       tts: (option as WebhookMessageOptions)?.tts,
       allowed_mentions: (option as WebhookMessageOptions)?.allowedMentions,
       components:
-        (option as WebhookMessageOptions).components === undefined
+        (option as WebhookMessageOptions)?.components === undefined
           ? undefined
-          : transformComponent((option as WebhookMessageOptions).components!)
+          : transformComponent((option as WebhookMessageOptions).components)
     }
 
     if ((option as WebhookMessageOptions)?.name !== undefined) {

--- a/src/structures/interactions.ts
+++ b/src/structures/interactions.ts
@@ -313,7 +313,7 @@ export class Interaction extends SnowflakeBase {
       components:
         (option as WebhookMessageOptions)?.components === undefined
           ? undefined
-          : transformComponent((option as WebhookMessageOptions).components)
+          : transformComponent((option as WebhookMessageOptions).components!)
     }
 
     if ((option as WebhookMessageOptions)?.name !== undefined) {


### PR DESCRIPTION
## About
Added missing `?` so `Interaction.send(...)` does not throw, when passing only a string.
Fixes #178

## Status
- [x] These changes have been tested against Discord API or do not contain API change.