### PR TITLE
Expose AuditLogEvents

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -157,7 +157,7 @@ export type {
   GuildCreateChannelOptions,
   GuildCreateRolePayload
 } from './src/types/guild.ts'
-export { AuditLogEvents } from './src/types/guild.ts';
+export { AuditLogEvents } from './src/types/guild.ts'
 export type { InvitePayload, PartialInvitePayload } from './src/types/invite.ts'
 export { PermissionFlags } from './src/types/permissionFlags.ts'
 export type {

--- a/mod.ts
+++ b/mod.ts
@@ -157,6 +157,7 @@ export type {
   GuildCreateChannelOptions,
   GuildCreateRolePayload
 } from './src/types/guild.ts'
+export { AuditLogEvents } from './src/types/guild.ts';
 export type { InvitePayload, PartialInvitePayload } from './src/types/invite.ts'
 export { PermissionFlags } from './src/types/permissionFlags.ts'
 export type {


### PR DESCRIPTION
## About

This enum is used to filter on type for fetching the audit log of a guild, but the enum itself is not exposed through `mod.ts`. This PR adds AuditLogEvents to the exported types.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
