### PR TITLE
Fix minor bug with webhooks so you can send with the avatar

### DIFF
--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -126,7 +126,7 @@ export class Webhook {
     }
 
     if ((option as WebhookMessageOptions)?.avatar !== undefined) {
-      payload.avatar = (option as WebhookMessageOptions)?.avatar
+      payload.avatar_url = (option as WebhookMessageOptions)?.avatar
     }
 
     if (


### PR DESCRIPTION
## About

This makes a change to fix a bug in Harmony, so now you can have webhooks send a message with the avatar URL.
This doesn't change the API at all

## Status

- [✓] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
