### PR TITLE
Fix not being able to respond with ephemeral message

### DIFF
--- a/src/structures/interactions.ts
+++ b/src/structures/interactions.ts
@@ -167,14 +167,14 @@ export class Interaction extends SnowflakeBase {
         data.content !== undefined ||
         data.embeds !== undefined ||
         data.components !== undefined ||
-        data.flags !== undefined ||
-        data.type === InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE
+        data.type === InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE ||
+        data.type === InteractionResponseType.DEFERRED_CHANNEL_MESSAGE
           ? {
               content: data.content ?? '',
               embeds: data.embeds,
               tts: data.tts ?? false,
               flags,
-              allowed_mentions: data.allowedMentions ?? undefined,
+              allowed_mentions: data.allowedMentions,
               components:
                 data.components === undefined
                   ? undefined

--- a/src/structures/interactions.ts
+++ b/src/structures/interactions.ts
@@ -167,6 +167,7 @@ export class Interaction extends SnowflakeBase {
         data.content !== undefined ||
         data.embeds !== undefined ||
         data.components !== undefined ||
+        data.flags !== undefined ||
         data.type === InteractionResponseType.CHANNEL_MESSAGE_WITH_SOURCE
           ? {
               content: data.content ?? '',


### PR DESCRIPTION
## About
`InteractionResponse.flags` ignored when sending response with `type = 5`. This caused `Interaction.defer(true)` to not behave as intended (did not send ephemeral message). I've added the missing check for `InteractionResponseType.DEFERRED_CHANNEL_MESSAGE`.

## Status
- [x] These changes have been tested against Discord API or do not contain API change.

btw, I've not created an issue before making a pull request (as opposed to my last contribution) because I was gonna fix it myself anyway. If in the future you want me to always create an issue beforehand just let me know; it just seemed like a waste of time.