### PR TITLE
Fix audit log typing

### DIFF
--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -678,7 +678,7 @@ export class Guild extends SnowflakeBase {
     }
 
     if ('webhooks' in data) {
-      ret.webhooks = data.webhooks;
+      ret.webhooks = data.webhooks
     }
 
     return ret


### PR DESCRIPTION
## About
The `AuditLogPayload` type returned by the `Guild#fetchAuditLog()` function did not match the actual structure of the data. The `AuditLog` type *did* contain the correct structure but was unused. This PR fixes these issues by assigning and returning the correct type within `fetchAuditLog`.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [x] This PR introduces some Breaking changes.
