### PR TITLE
fix 1 spelling mistake

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -66,7 +66,7 @@ export interface ClientOptions {
   fetchGatewayInfo?: boolean
   /** ADVANCED: Shard ID to launch on */
   shard?: number
-  /** ADVACNED: Shard count. */
+  /** ADVANCED: Shard count. */
   shardCount?: number | 'auto'
   /** Whether to enable Zlib Compression (for Gateway) or not (enabled by default) */
   compress?: boolean


### PR DESCRIPTION
## About

I noticed that there was a spelling mistake in the client options docs, so I fixed it.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [x] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
