### PR TITLE
fix: Keep description for slash groups and subcommands.

### DIFF
--- a/src/interactions/slashCommand.ts
+++ b/src/interactions/slashCommand.ts
@@ -113,11 +113,7 @@ function createSlashOption(
   return {
     name: data.name,
     type,
-    description:
-      type === SlashCommandOptionType.SUB_COMMAND ||
-      type === SlashCommandOptionType.SUB_COMMAND_GROUP
-        ? undefined
-        : data.description ?? 'No description.',
+    description: data.description ?? 'No description.',
     options: data.options?.map((e) =>
       typeof e === 'function' ? e(SlashOption) : e
     ),

--- a/src/types/slashCommands.ts
+++ b/src/types/slashCommands.ts
@@ -67,8 +67,8 @@ export interface SlashCommandOptionBase<
 > {
   /** Name of the option. */
   name: string
-  /** Description of the Option. Not required in Sub-Command-Group */
-  description?: string
+  /** Description of the Option. */
+  description: string
   /** Option type */
   type: OptionType
   /** Whether the option is required or not, false by default */

--- a/test/slash-builder.ts
+++ b/test/slash-builder.ts
@@ -1,0 +1,47 @@
+import { Client, Intents, event } from '../mod.ts'
+import { SlashBuilder, SlashOption } from '../src/interactions/slashCommand.ts'
+import { TOKEN, GUILD } from './config.ts'
+
+export class MyClient extends Client {
+  @event() ready(): void {
+    console.log(`Logged in as ${this.user?.tag}!`)
+    this.slash.commands.bulkEdit(
+      [
+        new SlashBuilder('test')
+          .description('Test command made with builder.')
+          .option(
+            SlashOption.subCommandGroup({
+              name: 'group',
+              description: 'Group description.',
+              options: [
+                SlashOption.subCommand({
+                  name: 'sub',
+                  description: 'Subcommand description.',
+                  options: [
+                    SlashOption.bool({ name: 'bool' }),
+                    SlashOption.channel({ name: 'channel' }),
+                    SlashOption.number({ name: 'number' }),
+                    SlashOption.role({ name: 'role' }),
+                    SlashOption.string({ name: 'string' }),
+                    SlashOption.user({ name: 'user' })
+                  ]
+                })
+              ]
+            })
+          )
+          .export()
+      ],
+      GUILD
+    )
+    this.slash.commands.bulkEdit([])
+  }
+}
+
+const client = new MyClient({
+  presence: {
+    status: 'dnd',
+    activity: { name: 'Slash Commands', type: 'LISTENING' }
+  }
+})
+
+client.connect(TOKEN, Intents.None)

--- a/test/slash-only.ts
+++ b/test/slash-only.ts
@@ -1,6 +1,6 @@
-import { SlashClient } from '../models/slashClient.ts'
-import { SlashCommandPartial } from '../types/slash.ts'
-import { TOKEN } from './config.ts'
+import { SlashClient } from '../src/interactions/slashClient.ts'
+import { SlashCommandPartial } from '../src/types/slashCommands.ts'
+import { TOKEN, GUILD } from './config.ts'
 
 export const slash = new SlashClient({ token: TOKEN })
 
@@ -12,7 +12,7 @@ const commands: SlashCommandPartial[] = []
 console.log('Creating...')
 commands.forEach((cmd) => {
   slash.commands
-    .create(cmd, '!! Your testing guild ID comes here !!')
+    .create(cmd, GUILD)
     .then((c) => console.log(`Created command ${c.name}!`))
     .catch((e) => `Failed to create ${cmd.name} - ${e.message}`)
 })

--- a/test/slash.ts
+++ b/test/slash.ts
@@ -1,42 +1,66 @@
 import { Client, Intents, event, slash } from '../mod.ts'
 import { SlashCommandInteraction } from '../src/structures/slash.ts'
-import { TOKEN } from './config.ts'
+import { SlashCommandOptionType as Type } from '../src/types/slashCommands.ts'
+import { TOKEN, GUILD } from './config.ts'
 
 export class MyClient extends Client {
   @event() ready(): void {
     console.log(`Logged in as ${this.user?.tag}!`)
-    // this.slash.commands.bulkEdit(
-    //   [
-    //     {
-    //       name: 'test',
-    //       description: 'Test command.',
-    //       options: [
-    //         {
-    //           name: 'user',
-    //           type: Type.USER,
-    //           description: 'User'
-    //         },
-    //         {
-    //           name: 'role',
-    //           type: Type.ROLE,
-    //           description: 'Role'
-    //         },
-    //         {
-    //           name: 'channel',
-    //           type: Type.CHANNEL,
-    //           description: 'Channel'
-    //         },
-    //         {
-    //           name: 'string',
-    //           type: Type.STRING,
-    //           description: 'String'
-    //         }
-    //       ]
-    //     }
-    //   ],
-    //   '807935370556866560'
-    // )
-    // this.slash.commands.bulkEdit([])
+    this.slash.commands.bulkEdit(
+      [
+        {
+          name: 'test',
+          description: 'Test command.',
+          options: [
+            {
+              name: 'user',
+              type: Type.USER,
+              description: 'User'
+            },
+            {
+              name: 'role',
+              type: Type.ROLE,
+              description: 'Role'
+            },
+            {
+              name: 'channel',
+              type: Type.CHANNEL,
+              description: 'Channel'
+            },
+            {
+              name: 'string',
+              type: Type.STRING,
+              description: 'String'
+            }
+          ]
+        },
+        {
+          name: 'test2',
+          description: 'Test command with a group and subcommands.',
+          options: [
+            {
+              name: 'group',
+              description: 'Test group.',
+              type: Type.SUB_COMMAND_GROUP,
+              options: [
+                {
+                  name: 'sub1',
+                  description: 'Test subcommand 1.',
+                  type: Type.SUB_COMMAND
+                },
+                {
+                  name: 'sub2',
+                  description: 'Test subcommand 2.',
+                  type: Type.SUB_COMMAND
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      GUILD
+    )
+    this.slash.commands.bulkEdit([])
   }
 
   @slash() test(d: SlashCommandInteraction): void {


### PR DESCRIPTION
## About

`SlashBuilder` drops the description field from an option when the type was SUB_COMMAND or SUB_COMMAND_GROUP. This would cause the API to return an error when uploading the slash commands because [`description` is a required field](https://discord.com/developers/docs/interactions/slash-commands#application-command-object-application-command-option-structure).

This PR drops the removal of `description`, so that groups and subcommands can be created through the builder.

I also fixed the slash.ts and slash-only.ts tests as I used them for testing before making slash-builder.ts

#### Example error from running test/slash-builder.ts:
```
PUT https://discord.com/api/v8/applications/329830967328112651/guilds/202898980223451136/commands returned 400
(50035) Invalid Form Body
  at 0.options[0].description:
   - BASE_TYPE_REQUIRED: This field is required
  at 0.options[0].options[0].description:
   - BASE_TYPE_REQUIRED: This field is required

      throw new DiscordAPIError({
            ^
    at BucketHandler.execute (file:///D:/Deving/modules/Deno-Harmony/src/rest/bucket.ts:217:13)
    at async BucketHandler.push (file:///D:/Deving/modules/Deno-Harmony/src/rest/bucket.ts:51:14)
    at async RESTManager.make (file:///D:/Deving/modules/Deno-Harmony/src/rest/manager.ts:236:12)
    at async RESTManager.put (file:///D:/Deving/modules/Deno-Harmony/src/rest/manager.ts:339:12)
    at async Proxy.<anonymous> (file:///D:/Deving/modules/Deno-Harmony/src/rest/manager.ts:47:11)
    at async SlashCommandsManager.bulkEdit (file:///D:/Deving/modules/Deno-Harmony/src/interactions/slashCommand.ts:546:15)
```

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
