### PR TITLE
Add `onMissingArgs` method to `Command`

### DIFF
--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -350,26 +350,24 @@ export class CommandClient extends Client implements CommandClientOptions {
     }
 
     if (command.args !== undefined) {
-      if (typeof command.args === 'boolean' && parsed.args.length === 0)
+      if (parsed.args.length === 0) {
         try {
           return await command.onMissingArgs(ctx)
         } catch (e) {
           return this.emit('commandMissingArgs', ctx)
         }
-      else if (
-        typeof command.args === 'number' &&
-        parsed.args.length < command.args
-      )
-      try {
-        return await command.onMissingArgs(ctx)
-      } catch (e) {
-        return this.emit('commandMissingArgs', ctx)
+      }
+      else if (parsed.args.length < command.args.length) {
+        try {
+          return await command.onMissingArgs(ctx)
+        } catch (e) {
+          return this.emit('commandMissingArgs', ctx)
+        } 
       }
     }
 
     try {
       this.emit('commandUsed', ctx)
-
       const beforeExecute = await command.beforeExecute(ctx)
       if (beforeExecute === false) return
 

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -351,12 +351,20 @@ export class CommandClient extends Client implements CommandClientOptions {
 
     if (command.args !== undefined) {
       if (typeof command.args === 'boolean' && parsed.args.length === 0)
-        return this.emit('commandMissingArgs', ctx)
+        try {
+          return await command.onMissingArgs(ctx)
+        } catch (e) {
+          return this.emit('commandMissingArgs', ctx)
+        }
       else if (
         typeof command.args === 'number' &&
         parsed.args.length < command.args
       )
-        this.emit('commandMissingArgs', ctx)
+      try {
+        return await command.onMissingArgs(ctx)
+      } catch (e) {
+        return this.emit('commandMissingArgs', ctx)
+      }
     }
 
     try {

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -349,20 +349,11 @@ export class CommandClient extends Client implements CommandClientOptions {
       }
     }
 
-    if (command.args !== undefined) {
-      if (parsed.args.length === 0) {
-        try {
+    if (command.args !== undefined && (parsed.args.length === 0 || parsed.args.length < command.args.length)) {
+      try {
           return await command.onMissingArgs(ctx)
-        } catch (e) {
+      } catch (e) {
           return this.emit('commandMissingArgs', ctx)
-        }
-      }
-      else if (parsed.args.length < command.args.length) {
-        try {
-          return await command.onMissingArgs(ctx)
-        } catch (e) {
-          return this.emit('commandMissingArgs', ctx)
-        } 
       }
     }
 

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -349,11 +349,14 @@ export class CommandClient extends Client implements CommandClientOptions {
       }
     }
 
-    if (command.args !== undefined && (parsed.args.length === 0 || parsed.args.length < command.args.length)) {
+    if (
+      command.args !== undefined &&
+      (parsed.args.length === 0 || parsed.args.length < command.args.length)
+    ) {
       try {
-          return await command.onMissingArgs(ctx)
+        return await command.onMissingArgs(ctx)
       } catch (e) {
-          return this.emit('commandMissingArgs', ctx)
+        return this.emit('commandMissingArgs', ctx)
       }
     }
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -105,6 +105,9 @@ export class Command implements CommandOptions {
   /** Method called when the command errors */
   onError(ctx: CommandContext, error: Error): any {}
 
+  /** Method called when there are missing arguments */
+  onMissingArgs(ctx: CommandContext): any {}
+
   /** Method executed before executing actual command. Returns bool value - whether to continue or not (optional) */
   beforeExecute(ctx: CommandContext): boolean | Promise<boolean> {
     return true


### PR DESCRIPTION
## About
Closes #182 
Introduces a `onMissingArgs` method to `Command` and does the appropriate changes to make it work, this allows for more granular missing arg responses 

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
