### PR TITLE
feat(CommandContext): add member property that resolves to Member of the author

### DIFF
--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -244,7 +244,7 @@ export class CommandClient extends Client implements CommandClientOptions {
       args: parseArgs(command.args, parsed.args),
       argString: parsed.argString,
       message: msg,
-      author: msg.author,
+      author: await msg.guild?.members.fetch(msg.author.id),
       command,
       channel: msg.channel,
       guild: msg.guild

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -245,6 +245,7 @@ export class CommandClient extends Client implements CommandClientOptions {
       argString: parsed.argString,
       message: msg,
       author: msg.author,
+      member: msg.member,
       command,
       channel: msg.channel,
       guild: msg.guild

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -244,7 +244,7 @@ export class CommandClient extends Client implements CommandClientOptions {
       args: parseArgs(command.args, parsed.args),
       argString: parsed.argString,
       message: msg,
-      author: await msg.guild?.members.fetch(msg.author.id),
+      author: msg.author,
       command,
       channel: msg.channel,
       guild: msg.guild

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -7,6 +7,7 @@ import type { CommandClient } from './client.ts'
 import type { Extension } from './extension.ts'
 import { join, walk } from '../../deps.ts'
 import type { Args } from '../utils/command.ts'
+import { Member } from "../structures/member.ts";
 
 export interface CommandContext {
   /** The Client object */
@@ -14,7 +15,7 @@ export interface CommandContext {
   /** Message which was parsed for Command */
   message: Message
   /** The Author of the Message */
-  author: User
+  author: Member | undefined
   /** The Channel in which Command was used */
   channel: TextChannel
   /** Prefix which was used */

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,12 +1,13 @@
 import type { Guild } from '../structures/guild.ts'
 import type { Message } from '../structures/message.ts'
 import type { TextChannel } from '../structures/textChannel.ts'
+import type { User } from '../structures/user.ts'
 import { Collection } from '../utils/collection.ts'
 import type { CommandClient } from './client.ts'
 import type { Extension } from './extension.ts'
 import { join, walk } from '../../deps.ts'
 import type { Args } from '../utils/command.ts'
-import { Member } from '../structures/member.ts'
+import { Member } from "../structures/member.ts";
 
 export interface CommandContext {
   /** The Client object */

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -1,13 +1,12 @@
 import type { Guild } from '../structures/guild.ts'
 import type { Message } from '../structures/message.ts'
 import type { TextChannel } from '../structures/textChannel.ts'
-import type { User } from '../structures/user.ts'
 import { Collection } from '../utils/collection.ts'
 import type { CommandClient } from './client.ts'
 import type { Extension } from './extension.ts'
 import { join, walk } from '../../deps.ts'
 import type { Args } from '../utils/command.ts'
-import { Member } from "../structures/member.ts";
+import { Member } from '../structures/member.ts'
 
 export interface CommandContext {
   /** The Client object */

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -7,6 +7,7 @@ import type { CommandClient } from './client.ts'
 import type { Extension } from './extension.ts'
 import { join, walk } from '../../deps.ts'
 import type { Args } from '../utils/command.ts'
+import { Member } from '../structures/member.ts'
 
 export interface CommandContext {
   /** The Client object */
@@ -15,6 +16,8 @@ export interface CommandContext {
   message: Message
   /** The Author of the Message */
   author: User
+  /** The Author of the message as a Member object */
+  member?: Member
   /** The Channel in which Command was used */
   channel: TextChannel
   /** Prefix which was used */

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -7,7 +7,6 @@ import type { CommandClient } from './client.ts'
 import type { Extension } from './extension.ts'
 import { join, walk } from '../../deps.ts'
 import type { Args } from '../utils/command.ts'
-import { Member } from "../structures/member.ts";
 
 export interface CommandContext {
   /** The Client object */
@@ -15,7 +14,7 @@ export interface CommandContext {
   /** Message which was parsed for Command */
   message: Message
   /** The Author of the Message */
-  author: Member | undefined
+  author: User
   /** The Channel in which Command was used */
   channel: TextChannel
   /** Prefix which was used */


### PR DESCRIPTION
## About

~~Makes the `author` property on `CommandContext` resolve to `Member` automatically, this is more or less for convenience, as many manually fetch the `Member` object of the author, and the `User` object is still accesible through `ctx.author.user`. Makes no sense to return the User when the author must be in the server if he sent a message with a command.~~

Adds a new `member` property on `CommandContext` that resolves to the `Member` of the author.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [] This PR introduces some Breaking changes.
