### PR TITLE
feat(slash): Add NUMBER option type

### DIFF
--- a/src/types/slashCommands.ts
+++ b/src/types/slashCommands.ts
@@ -58,7 +58,8 @@ export enum SlashCommandOptionType {
   USER = 6,
   CHANNEL = 7,
   ROLE = 8,
-  MENTIONABLE = 9
+  MENTIONABLE = 9,
+  NUMBER = 10
 }
 
 export interface SlashCommandOptionBase<


### PR DESCRIPTION
## About

Discord added a shiny new NUMBER slash command option type that supports floating point numbers. I believe this is the only change needed in Harmony to support it, seeing as only complex types are being explicitly handled in `SlashCommandInteraction<T>()`.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
