### PR TITLE
fix(export): MessageTypes members not exported

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -141,7 +141,6 @@ export type {
   MessageFlags,
   MessageStickerFormatTypes,
   MessageStickerItemPayload,
-  MessageTypes,
   OverwriteAsArg,
   Overwrite,
   EmbedVideo,

--- a/mod.ts
+++ b/mod.ts
@@ -111,7 +111,8 @@ export type {
 export {
   ChannelTypes,
   OverwriteType,
-  OverrideType
+  OverrideType,
+  MessageTypes
 } from './src/types/channel.ts'
 export type { ApplicationPayload } from './src/types/application.ts'
 export type { ImageFormats, ImageSize } from './src/types/cdn.ts'


### PR DESCRIPTION
## About
Because comparing `Message.type` to numbers is ugly as hell.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
