### PR TITLE
fix(rest): not sending Content-Length header when the body is undefined

### DIFF
--- a/src/managers/memberRoles.ts
+++ b/src/managers/memberRoles.ts
@@ -63,35 +63,27 @@ export class MemberRolesManager extends BaseChildManager<RolePayload, Role> {
   }
 
   async add(role: string | Role, reason?: string): Promise<boolean> {
-    const res = await this.client.rest.put(
+    await this.client.rest.put(
       GUILD_MEMBER_ROLE(
         this.member.guild.id,
         this.member.id,
         typeof role === 'string' ? role : role.id
       ),
-      { reason },
-      undefined,
-      undefined,
-      true,
       { reason }
     )
 
-    return res.response.status === 204
+    return true
   }
 
   async remove(role: string | Role): Promise<boolean> {
-    const res = await this.client.rest.delete(
+    await this.client.rest.delete(
       GUILD_MEMBER_ROLE(
         this.member.guild.id,
         this.member.id,
         typeof role === 'string' ? role : role.id
-      ),
-      undefined,
-      undefined,
-      undefined,
-      true
+      )
     )
 
-    return res.response.status === 204
+    return true
   }
 }

--- a/src/managers/memberRoles.ts
+++ b/src/managers/memberRoles.ts
@@ -69,6 +69,10 @@ export class MemberRolesManager extends BaseChildManager<RolePayload, Role> {
         this.member.id,
         typeof role === 'string' ? role : role.id
       ),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
       { reason }
     )
 

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -135,6 +135,11 @@ export class APIRequest {
           : `${this.rest.tokenType} ${this.rest.token}`.trim()
     }
 
+    // TODO: Remove once https://github.com/denoland/deno/issues/11920 is fixed
+    if ((this.method === 'post' || this.method === 'put') && (body === undefined || body === null)) {
+      headers['Content-Length'] = '0'
+    }
+
     if (contentType !== undefined) headers['Content-Type'] = contentType
 
     const init: RequestInit = {

--- a/src/rest/request.ts
+++ b/src/rest/request.ts
@@ -136,7 +136,10 @@ export class APIRequest {
     }
 
     // TODO: Remove once https://github.com/denoland/deno/issues/11920 is fixed
-    if ((this.method === 'post' || this.method === 'put') && (body === undefined || body === null)) {
+    if (
+      (this.method === 'post' || this.method === 'put') &&
+      (body === undefined || body === null)
+    ) {
       headers['Content-Length'] = '0'
     }
 

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -118,12 +118,12 @@ export class GuildBans extends Base {
     const res = await this.client.rest.put(
       GUILD_BAN(this.guild.id, typeof user === 'string' ? user : user.id),
       {
-        reason,
         delete_message_days: deleteMessagesDays
       },
       undefined,
       null,
-      true
+      true,
+      { reason }
     )
     if (res.response.status !== 204) throw new Error('Failed to Add Guild Ban')
   }
@@ -131,10 +131,16 @@ export class GuildBans extends Base {
   /**
    * Unbans (removes ban from) a User.
    * @param user User to unban, ID or User object.
+   * @param reason Reason for the Unban.
    */
-  async remove(user: string | User): Promise<boolean> {
+  async remove(user: string | User, reason?: string): Promise<boolean> {
     await this.client.rest.delete(
-      GUILD_BAN(this.guild.id, typeof user === 'string' ? user : user.id)
+      GUILD_BAN(this.guild.id, typeof user === 'string' ? user : user.id),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      { reason }
     )
 
     return true

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -133,16 +133,11 @@ export class GuildBans extends Base {
    * @param user User to unban, ID or User object.
    */
   async remove(user: string | User): Promise<boolean> {
-    const res = await this.client.rest.delete(
-      GUILD_BAN(this.guild.id, typeof user === 'string' ? user : user.id),
-      undefined,
-      undefined,
-      null,
-      true
+    await this.client.rest.delete(
+      GUILD_BAN(this.guild.id, typeof user === 'string' ? user : user.id)
     )
 
-    if (res.response.status !== 204) return false
-    else return true
+    return true
   }
 }
 

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -183,12 +183,9 @@ export class Member extends SnowflakeBase {
    * Kicks the member.
    */
   async kick(reason?: string): Promise<boolean> {
-    await this.client.rest.delete(
-      GUILD_MEMBER(this.guild.id, this.id),
-      {
-        reason
-      }
-    )
+    await this.client.rest.delete(GUILD_MEMBER(this.guild.id, this.id), {
+      reason
+    })
     return true
   }
 

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -183,18 +183,13 @@ export class Member extends SnowflakeBase {
    * Kicks the member.
    */
   async kick(reason?: string): Promise<boolean> {
-    const resp = await this.client.rest.delete(
+    await this.client.rest.delete(
       GUILD_MEMBER(this.guild.id, this.id),
-      undefined,
-      undefined,
-      null,
-      true,
       {
         reason
       }
     )
-    if (resp.ok !== true) return false
-    else return true
+    return true
   }
 
   /**

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -183,9 +183,16 @@ export class Member extends SnowflakeBase {
    * Kicks the member.
    */
   async kick(reason?: string): Promise<boolean> {
-    await this.client.rest.delete(GUILD_MEMBER(this.guild.id, this.id), {
-      reason
-    })
+    await this.client.rest.delete(
+      GUILD_MEMBER(this.guild.id, this.id),
+      undefined,
+      undefined,
+      null,
+      undefined,
+      {
+        reason
+      }
+    )
     return true
   }
 

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -187,9 +187,8 @@ export class Webhook {
 
   /** Deletes the Webhook. */
   async delete(): Promise<boolean> {
-    const resp = await this.rest.delete(this.url, undefined, 0, undefined, true)
-    if (resp.response.status !== 204) return false
-    else return true
+    await this.rest.delete(this.url)
+    return true
   }
 
   async editMessage(


### PR DESCRIPTION
## About

This PR fixes the rest doesn't send the `Content-Length` header when the body is undefined or null.
Very related to https://github.com/denoland/deno/issues/11920

Also, I removed all status checking codes since harmony will throw an error if the status is not 2xx.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
