### PR TITLE
feat(member): Guild member avatar fetching

### DIFF
--- a/src/gateway/handlers/guildMemberUpdate.ts
+++ b/src/gateway/handlers/guildMemberUpdate.ts
@@ -19,6 +19,7 @@ export const guildMemberUpdate: GatewayEventHandler = async (
     roles: d.roles,
     joined_at: d.joined_at,
     nick: d.nick,
+    avatar: d.avatar,
     premium_since: d.premium_since,
     deaf: member?.deaf ?? false,
     mute: member?.mute ?? false

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -1,6 +1,6 @@
 import { MemberRolesManager } from '../managers/memberRoles.ts'
 import type { Client } from '../client/mod.ts'
-import { GUILD_MEMBER } from '../types/endpoint.ts'
+import { GUILD_MEMBER, GUILD_MEMBER_AVATAR } from '../types/endpoint.ts'
 import type { MemberPayload } from '../types/guild.ts'
 import { Permissions } from '../utils/permissions.ts'
 import { SnowflakeBase } from './base.ts'
@@ -8,6 +8,8 @@ import type { Guild } from './guild.ts'
 import type { VoiceChannel } from './guildVoiceChannel.ts'
 import type { Role } from './role.ts'
 import type { User } from './user.ts'
+import { ImageURL } from './cdn.ts'
+import type { ImageSize, ImageFormats } from '../types/cdn.ts'
 
 export interface MemberData {
   nick?: string | null
@@ -21,6 +23,7 @@ export class Member extends SnowflakeBase {
   id: string
   user: User
   nick: string | null
+  avatar: string | null
   roles: MemberRolesManager
   joinedAt: string
   premiumSince?: string
@@ -40,6 +43,7 @@ export class Member extends SnowflakeBase {
     this.id = data.user.id
     this.user = user
     this.nick = data.nick
+    this.avatar = data.avatar
     this.guild = guild
     this.roles = new MemberRolesManager(this.client, this.guild.roles, this)
     this.joinedAt = data.joined_at
@@ -60,6 +64,7 @@ export class Member extends SnowflakeBase {
 
   readFromData(data: MemberPayload): void {
     this.nick = data.nick ?? this.nick
+    this.avatar = data.avatar ?? this.avatar
     this.joinedAt = data.joined_at ?? this.joinedAt
     this.premiumSince = data.premium_since ?? this.premiumSince
     this.deaf = data.deaf ?? this.deaf
@@ -230,5 +235,15 @@ export class Member extends SnowflakeBase {
     if (!manageable) return false
     const me = by ?? (await this.guild.me())
     return me.permissions.has('KICK_MEMBERS')
+  }
+
+  avatarURL(format: ImageFormats = 'png', size: ImageSize = 512): string {
+    return this.avatar !== null && this.avatar !== undefined
+      ? `${ImageURL(
+          GUILD_MEMBER_AVATAR(this.guild.id, this.user.id, this.avatar),
+          format,
+          size
+        )}`
+      : this.user.avatarURL(format, size)
   }
 }

--- a/src/types/endpoint.ts
+++ b/src/types/endpoint.ts
@@ -157,6 +157,12 @@ const DEFAULT_USER_AVATAR = (iconID: string): string =>
   `${Constants.DISCORD_CDN_URL}/embed/avatars/${iconID}`
 const USER_AVATAR = (userID: string, iconID: string): string =>
   `${Constants.DISCORD_CDN_URL}/avatars/${userID}/${iconID}`
+const GUILD_MEMBER_AVATAR = (
+  guildID: string,
+  userID: string,
+  iconID: string
+): string =>
+  `${Constants.DISCORD_CDN_URL}/guilds/${guildID}/users/${userID}/avatars/${iconID}`
 const APPLICATION_ASSET = (applicationID: string, assetID: string): string =>
   `${Constants.DISCORD_CDN_URL}/app-icons/${applicationID}/${assetID}`
 const ACHIEVEMENT_ICON = (
@@ -281,6 +287,7 @@ export {
   GUILD_BANNER,
   DEFAULT_USER_AVATAR,
   USER_AVATAR,
+  GUILD_MEMBER_AVATAR,
   APPLICATION_ASSET,
   ACHIEVEMENT_ICON,
   TEAM_ICON,

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -218,6 +218,7 @@ export interface GuildMemberUpdatePayload {
   roles: string[]
   user: UserPayload
   nick: string | null
+  avatar: string | null
   joined_at: string
   premium_since?: string | undefined
 }

--- a/src/types/guild.ts
+++ b/src/types/guild.ts
@@ -83,6 +83,7 @@ export interface GuildPayload {
 export interface MemberPayload {
   user: UserPayload
   nick: string | null
+  avatar: string | null
   roles: string[]
   joined_at: string
   premium_since?: string

--- a/test/index.ts
+++ b/test/index.ts
@@ -312,6 +312,12 @@ client.on('messageCreate', async (msg: Message) => {
   } else if (msg.content === '!getPins') {
     const pins = await msg.channel.getPinnedMessages()
     msg.channel.send(`Pinned messages: ${pins.map((pin) => pin.id).join('\n')}`)
+  } else if (msg.content === '!avatar') {
+    if (msg.member) {
+      msg.channel.send(msg.member.avatarURL())
+    } else {
+      msg.channel.send(msg.author.avatarURL())
+    }
   }
 })
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -313,7 +313,7 @@ client.on('messageCreate', async (msg: Message) => {
     const pins = await msg.channel.getPinnedMessages()
     msg.channel.send(`Pinned messages: ${pins.map((pin) => pin.id).join('\n')}`)
   } else if (msg.content === '!avatar') {
-    if (msg.member) {
+    if (msg.member !== undefined) {
       msg.channel.send(msg.member.avatarURL())
     } else {
       msg.channel.send(msg.author.avatarURL())


### PR DESCRIPTION
Closes #241

## About
Allows member server profile avatar fetching in a similar way to fetching user avatars. If no server profile avatar is set, it falls back to the underlying user's profile.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
