### PR TITLE
fix(message): Set channel in message constructor

### DIFF
--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -88,6 +88,7 @@ export class Message extends SnowflakeBase {
     super(client)
     this.id = data.id
     this.author = author
+    this.channel = channel
     this.mentions = new MessageMentions(this.client, this)
     this.reactions = new MessageReactionsManager(this.client, this)
     this.createdTimestamp = new Date(data.timestamp)


### PR DESCRIPTION
## About

`msg.channel.send` was broken in https://github.com/harmonyland/harmony/commit/6d7786dcd09b7474607248a7582e726920d7624b due to the channel not being added to the message object. This fixes that.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.