### PR TITLE
feat(role): Role icons

### DIFF
--- a/src/managers/roles.ts
+++ b/src/managers/roles.ts
@@ -1,4 +1,5 @@
 import { Permissions } from '../../mod.ts'
+import { fetchAuto } from '../../deps.ts'
 import type { Client } from '../client/mod.ts'
 import type { Guild } from '../structures/guild.ts'
 import { Role } from '../structures/role.ts'
@@ -101,6 +102,14 @@ export class RolesManager extends BaseManager<RolePayload, Role> {
   }
 
   async edit(role: Role | string, options: RoleModifyPayload): Promise<Role> {
+    if (
+      options.icon !== undefined &&
+      options.icon !== null &&
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      !options.icon.startsWith('data:')
+    ) {
+      options.icon = await fetchAuto(options.icon)
+    }
     if (role instanceof Role) {
       role = role.id
     }

--- a/src/structures/role.ts
+++ b/src/structures/role.ts
@@ -5,6 +5,9 @@ import { Permissions } from '../utils/permissions.ts'
 import type { Guild } from './guild.ts'
 import type { Member } from './member.ts'
 import { User } from './user.ts'
+import { ImageURL } from './cdn.ts'
+import { ImageFormats, ImageSize } from '../types/cdn.ts'
+import { ROLE_ICON } from '../types/endpoint.ts'
 
 /** Represents a Guild Role */
 export class Role extends SnowflakeBase {
@@ -13,6 +16,8 @@ export class Role extends SnowflakeBase {
   name!: string
   color!: number
   hoist!: boolean
+  icon?: string
+  unicodeEmoji?: string
   position!: number
   permissions!: Permissions
   managed!: boolean
@@ -30,6 +35,8 @@ export class Role extends SnowflakeBase {
     this.name = data.name ?? this.name
     this.color = data.color ?? this.color
     this.hoist = data.hoist ?? this.hoist
+    this.icon = data.icon ?? this.icon
+    this.unicodeEmoji = data.unicode_emoji ?? this.unicodeEmoji
     this.position = data.position ?? this.position
     this.permissions =
       data.permissions !== undefined
@@ -89,6 +96,16 @@ export class Role extends SnowflakeBase {
     }
 
     return member.roles.remove(this.id)
+  }
+
+  /** Get the icon for the role. If set, is either a URL to an icon, or a Unicode emoji. */
+  roleIcon(
+    format: ImageFormats = 'png',
+    size: ImageSize = 512
+  ): string | undefined {
+    return this.icon !== undefined
+      ? `${ImageURL(ROLE_ICON(this.id, this.icon), format, size)}`
+      : this.unicodeEmoji
   }
 }
 

--- a/src/types/endpoint.ts
+++ b/src/types/endpoint.ts
@@ -173,6 +173,8 @@ const ACHIEVEMENT_ICON = (
   `${Constants.DISCORD_CDN_URL}/app-assets/${applicationID}/achievements/${achievementID}/icons/${iconHASH}`
 const TEAM_ICON = (teamID: string, iconID: string): string =>
   `${Constants.DISCORD_CDN_URL}/team-icons/${teamID}/${iconID}`
+const ROLE_ICON = (roleID: string, iconID: string): string =>
+  `${Constants.DISCORD_CDN_URL}/role-icons/${roleID}/${iconID}`
 
 // Emoji Endpoints
 const EMOJI = (guildID: string, emojiID: string): string =>
@@ -291,6 +293,7 @@ export {
   APPLICATION_ASSET,
   ACHIEVEMENT_ICON,
   TEAM_ICON,
+  ROLE_ICON,
   EMOJI,
   TEMPLATE,
   INVITE,

--- a/src/types/role.ts
+++ b/src/types/role.ts
@@ -3,6 +3,8 @@ export interface RolePayload {
   name: string
   color: number
   hoist: boolean
+  icon?: string
+  unicode_emoji?: string
   position: number
   permissions: string
   managed: boolean
@@ -24,5 +26,7 @@ export interface RoleModifyPayload {
   permissions?: string | null
   color?: number | null
   hoist?: boolean | null
+  icon?: string | null
+  unicode_emoji?: string | null
   mentionable?: boolean | null
 }

--- a/test/index.ts
+++ b/test/index.ts
@@ -318,6 +318,19 @@ client.on('messageCreate', async (msg: Message) => {
     } else {
       msg.channel.send(msg.author.avatarURL())
     }
+  } else if (msg.content.startsWith('!roleIcon')) {
+    const size = msg.mentions.roles.size
+    const role = msg.mentions.roles.first()
+    const icon = role?.roleIcon()
+    if (size === 0) {
+      msg.channel.send('no role mentioned')
+    } else {
+      if (icon === undefined) {
+        msg.channel.send('no icon')
+      } else {
+        msg.channel.send(icon)
+      }
+    }
   }
 })
 

--- a/test/index.ts
+++ b/test/index.ts
@@ -331,6 +331,11 @@ client.on('messageCreate', async (msg: Message) => {
         msg.channel.send(icon)
       }
     }
+  } else if (msg.content === '!roleSmile') {
+    const role = await msg.guild?.roles.get('834440844270501888')
+    if (role !== undefined) {
+      role.edit({ unicode_emoji: '😀' })
+    }
   }
 })
 


### PR DESCRIPTION
## About

Adds the ability to fetch and upload role icons. Completely untested (apart from the fact that `role.roleIcon()` correctly returns `undefined` if there is no icon and that trying to update a role with a unicode emoji gives a boost error on unboosted guilds) so if you have a dev server that's boosted 7+ times go right ahead

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
