### PR TITLE
feat(member): Add function for effective color

### DIFF
--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -240,4 +240,12 @@ export class Member extends SnowflakeBase {
         )}`
       : this.user.avatarURL(format, size)
   }
+
+  async effectiveColor(): Promise<number> {
+    return (
+      (await this.roles.array())
+        .sort((a, b) => b.position - a.position)
+        .find((r) => r.color !== 0)?.color ?? 0
+    )
+  }
 }

--- a/src/utils/colorutil.ts
+++ b/src/utils/colorutil.ts
@@ -196,7 +196,7 @@ export class ColorUtil {
    */
   static intToHex(color: number): string {
     if (!ColorUtil.validateColor(color)) throw new Error('Invalid color')
-    return `#${color.toString(16)}`
+    return `#${color.toString(16).padStart(6, '0')}`
   }
 
   /**

--- a/test/index.ts
+++ b/test/index.ts
@@ -13,7 +13,8 @@ import {
   Permissions,
   Collector,
   MessageAttachment,
-  OverrideType
+  OverrideType,
+  ColorUtil
 } from '../mod.ts'
 import { TOKEN } from './config.ts'
 
@@ -318,6 +319,12 @@ client.on('messageCreate', async (msg: Message) => {
     } else {
       msg.channel.send(msg.author.avatarURL())
     }
+  } else if (msg.content === '!color') {
+    msg.channel.send(
+      msg.member !== undefined
+        ? ColorUtil.intToHex(await msg.member.effectiveColor())
+        : 'not in a guild'
+    )
   }
 })
 


### PR DESCRIPTION
## About

Adds a utility function for getting the member's effective (display) color, based on role positions. Also includes a fix to the color utility class, making sure that hex colors are padded to 6 characters in all situations.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
