### PR TITLE
fix(interaction): use components after defer

### DIFF
--- a/src/structures/interactions.ts
+++ b/src/structures/interactions.ts
@@ -262,7 +262,8 @@ export class Interaction extends SnowflakeBase {
         content: options.content,
         embeds: options.embeds,
         flags: options.flags,
-        allowedMentions: options.allowedMentions
+        allowedMentions: options.allowedMentions,
+        components: options.components
       })
     } else {
       await this.respond(


### PR DESCRIPTION
## About
Interaction.reply() didn't take components into account when editing the response after the interaction had been deferred, so they would never show up under the message.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
