### PR TITLE
Export AuditLog-Types in mod.ts

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -120,6 +120,12 @@ export * from './src/types/channel.ts'
 export type { EmojiPayload } from './src/types/emoji.ts'
 export { Verification } from './src/types/guild.ts'
 export type {
+  AuditLog,
+  AuditLogChange,
+  AuditLogChangePayload,
+  AuditLogEntry,
+  AuditLogEntryPayload,
+  AuditLogPayload,
   GuildIntegrationPayload,
   GuildPayload,
   GuildBanPayload,
@@ -128,19 +134,11 @@ export type {
   GuildTextBasedChannels,
   GuildCreateOptions,
   GuildCreateChannelOptions,
-  GuildCreateRolePayload
-} from './src/types/guild.ts'
-export {
-  AuditLog,
-  AuditLofChange,
-  AuditLogChangePayload,
-  AuditLogEntry,
-  AuditLogEntryPayload,
-  AuditLogEvents,
-  AuditLogPayload,
+  GuildCreateRolePayload,
   OptionalAuditEntryInfo,
   OptionalAuditEntryInfoPayload
 } from './src/types/guild.ts'
+export { AuditLogEvents } from './src/types/guild.ts'
 export type { InvitePayload, PartialInvitePayload } from './src/types/invite.ts'
 export { PermissionFlags } from './src/types/permissionFlags.ts'
 export type {

--- a/mod.ts
+++ b/mod.ts
@@ -130,7 +130,17 @@ export type {
   GuildCreateChannelOptions,
   GuildCreateRolePayload
 } from './src/types/guild.ts'
-export { AuditLogEvents } from './src/types/guild.ts'
+export {
+  AuditLog,
+  AuditLofChange,
+  AuditLogChangePayload,
+  AuditLogEntry,
+  AuditLogEntryPayload,
+  AuditLogEvents,
+  AuditLogPayload,
+  OptionalAuditEntryInfo,
+  OptionalAuditEntryInfoPayload
+} from './src/types/guild.ts'
 export type { InvitePayload, PartialInvitePayload } from './src/types/invite.ts'
 export { PermissionFlags } from './src/types/permissionFlags.ts'
 export type {


### PR DESCRIPTION
## About

Exports AuditLog-Types in mod.ts, so that they can be imported easily in own project to properly work with AuditLogs.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
