### PR TITLE
feat(Member): set and reset guild timeouts

### DIFF
--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -154,10 +154,10 @@ export class Member extends SnowflakeBase {
   }
 
   /**
-   * Sets Guild Timeout for the Member
+   * Sets Timeout for the Member
    * @param expiration Value to set
    */
-  async setGuildTimeout(expiration?: Date, reason?: string): Promise<Member> {
+  async setTimeout(expiration?: Date, reason?: string): Promise<Member> {
     return await this.edit(
       {
         communicationDisabledUntil: expiration
@@ -167,10 +167,10 @@ export class Member extends SnowflakeBase {
   }
 
   /**
-   * Resets Guild Timeout for the Member
+   * Resets Timeout for the Member
    */
-  async resetGuildTimeout(reason?: string): Promise<Member> {
-    return await this.setGuildTimeout(undefined, reason)
+  async resetTimeout(reason?: string): Promise<Member> {
+    return await this.setTimeout(undefined, reason)
   }
 
   /**

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -17,7 +17,7 @@ export interface MemberData {
   deaf?: boolean
   mute?: boolean
   channel?: string | VoiceChannel | null
-  communicationDisabledUntil?: Date
+  communicationDisabledUntil?: Date | null
 }
 
 export class Member extends SnowflakeBase {
@@ -157,7 +157,7 @@ export class Member extends SnowflakeBase {
    * Sets Timeout for the Member
    * @param expiration Value to set
    */
-  async setTimeout(expiration?: Date, reason?: string): Promise<Member> {
+  async setTimeout(expiration?: Date | null, reason?: string): Promise<Member> {
     return await this.edit(
       {
         communicationDisabledUntil: expiration
@@ -170,7 +170,7 @@ export class Member extends SnowflakeBase {
    * Resets Timeout for the Member
    */
   async resetTimeout(reason?: string): Promise<Member> {
-    return await this.setTimeout(undefined, reason)
+    return await this.setTimeout(null, reason)
   }
 
   /**

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -154,6 +154,26 @@ export class Member extends SnowflakeBase {
   }
 
   /**
+   * Sets Guild Timeout for the Member
+   * @param expiration Value to set
+   */
+  async setGuildTimeout(expiration?: Date, reason?: string): Promise<Member> {
+    return await this.edit(
+      {
+        communicationDisabledUntil: expiration
+      },
+      reason
+    )
+  }
+
+  /**
+   * Resets Guild Timeout for the Member
+   */
+  async resetGuildTimeout(reason?: string): Promise<Member> {
+    return await this.setGuildTimeout(undefined, reason)
+  }
+
+  /**
    * Sets a Member deaf in VC
    * @param deaf Value to set
    */


### PR DESCRIPTION
## About

Adds setGuildTimeout and resetGuildTimeout functions to easily modify guild timeouts for a Member.
Previously, you could only do this by using Member.edit

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
