### PR TITLE
Update misleading docs for `permissions` property

### DIFF
--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -30,6 +30,7 @@ export class Member extends SnowflakeBase {
   deaf!: boolean
   mute!: boolean
   guild: Guild
+  /** Use `edit` method to update permissions */
   permissions: Permissions
   communicationDisabledUntil?: Date | null
 

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -30,7 +30,6 @@ export class Member extends SnowflakeBase {
   deaf!: boolean
   mute!: boolean
   guild: Guild
-  /** Use `edit` method to update permissions */
   permissions: Permissions
   communicationDisabledUntil?: Date | null
 

--- a/src/structures/role.ts
+++ b/src/structures/role.ts
@@ -19,6 +19,7 @@ export class Role extends SnowflakeBase {
   icon?: string
   unicodeEmoji?: string
   position!: number
+  /** Use `edit` method to update permissions */
   permissions!: Permissions
   managed!: boolean
   mentionable!: boolean

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -4,7 +4,7 @@ import { BitField, BitFieldResolvable } from './bitfield.ts'
 
 export type PermissionResolvable = BitFieldResolvable
 
-/** Manages Discord's Bit-based Permissions (updates only locally) */
+/** Represents permissions BitField */
 export class Permissions extends BitField {
   static DEFAULT = 104324673n
   static ALL = Object.values(PermissionFlags).reduce(

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -4,7 +4,7 @@ import { BitField, BitFieldResolvable } from './bitfield.ts'
 
 export type PermissionResolvable = BitFieldResolvable
 
-/** Manages Discord's Bit-based Permissions */
+/** Manages Discord's Bit-based Permissions (updates only locally) */
 export class Permissions extends BitField {
   static DEFAULT = 104324673n
   static ALL = Object.values(PermissionFlags).reduce(
@@ -19,14 +19,14 @@ export class Permissions extends BitField {
   any(permission: PermissionResolvable, checkAdmin = true): boolean {
     return (
       (checkAdmin && super.has(this.flags().ADMINISTRATOR)) ||
-      super.any(permission as any)
+      super.any(permission)
     )
   }
 
   has(permission: PermissionResolvable, checkAdmin = true): boolean {
     return (
       (checkAdmin && super.has(this.flags().ADMINISTRATOR)) ||
-      super.has(permission as any)
+      super.has(permission)
     )
   }
 }


### PR DESCRIPTION
## About

`Member` and `Role` structures both don't contain docs about actual usage of `permissions` property. Also, `Permissions` contains misleading docs about itself, which implies that the `Permissions` class uses the Rest API when it actually doesn't.

## Status

- [X] These changes have been tested against Discord API or do not contain API change.
- [X] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
