### PR TITLE
Add a url field to messages and add .setCategory function for guild channels

### DIFF
--- a/src/structures/channel.ts
+++ b/src/structures/channel.ts
@@ -198,6 +198,15 @@ export class GuildChannel extends Channel {
 
     return overwrites
   }
+  
+  /** Edit category of the channel */
+  async setCategory(
+    category: CategoryChannel | string
+  ): Promise<GuildTextBasedChannel> {
+    return await this.edit({
+      parentID: typeof category === 'object' ? category.id : category
+    })
+  }
 
   /** Get Permissions for a Member in this Channel */
   async permissionsFor(target: Member | Role | string): Promise<Permissions> {

--- a/src/structures/channel.ts
+++ b/src/structures/channel.ts
@@ -198,7 +198,7 @@ export class GuildChannel extends Channel {
 
     return overwrites
   }
-  
+
   /** Edit category of the channel */
   async setCategory(
     category: CategoryChannel | string

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -74,10 +74,13 @@ export class Message extends SnowflakeBase {
   interaction?: MessageInteraction
   createdTimestamp: Date
   components: MessageComponentData[] = []
-  url: string
 
   get createdAt(): Date {
     return this.createdTimestamp // new Date(this.timestamp)
+  }
+  
+  get url(): string {
+    return CHANNEL_MESSAGE(this.channelID, this.id)
   }
 
   constructor(
@@ -116,7 +119,6 @@ export class Message extends SnowflakeBase {
     this.application = data.application ?? this.application
     this.messageReference = data.message_reference ?? this.messageReference
     this.flags = data.flags ?? this.flags
-    this.url = `https://discord.com/channels/${this.guildID || "@me"}/${this.channelID}/${this.id}`
     this.stickerItems =
       data.sticker_items !== undefined
         ? data.sticker_items.map(

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -74,6 +74,7 @@ export class Message extends SnowflakeBase {
   interaction?: MessageInteraction
   createdTimestamp: Date
   components: MessageComponentData[] = []
+  url: string
 
   get createdAt(): Date {
     return this.createdTimestamp // new Date(this.timestamp)
@@ -115,6 +116,7 @@ export class Message extends SnowflakeBase {
     this.application = data.application ?? this.application
     this.messageReference = data.message_reference ?? this.messageReference
     this.flags = data.flags ?? this.flags
+    this.url = `https://discord.com/channels/${data.guild_id}/${data.channel_id}/${this.id}`
     this.stickerItems =
       data.sticker_items !== undefined
         ? data.sticker_items.map(

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -116,7 +116,7 @@ export class Message extends SnowflakeBase {
     this.application = data.application ?? this.application
     this.messageReference = data.message_reference ?? this.messageReference
     this.flags = data.flags ?? this.flags
-    this.url = `https://discord.com/channels/${data.guild_id || "@me"}/${data.channel_id}/${this.id}`
+    this.url = `https://discord.com/channels/${this.guildID || "@me"}/${this.channelID}/${this.id}`
     this.stickerItems =
       data.sticker_items !== undefined
         ? data.sticker_items.map(

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -116,7 +116,7 @@ export class Message extends SnowflakeBase {
     this.application = data.application ?? this.application
     this.messageReference = data.message_reference ?? this.messageReference
     this.flags = data.flags ?? this.flags
-    this.url = `https://discord.com/channels/${data.guild_id}/${data.channel_id}/${this.id}`
+    this.url = `https://discord.com/channels/${data.guild_id || "@me"}/${data.channel_id}/${this.id}`
     this.stickerItems =
       data.sticker_items !== undefined
         ? data.sticker_items.map(

--- a/src/structures/message.ts
+++ b/src/structures/message.ts
@@ -78,7 +78,7 @@ export class Message extends SnowflakeBase {
   get createdAt(): Date {
     return this.createdTimestamp // new Date(this.timestamp)
   }
-  
+
   get url(): string {
     return CHANNEL_MESSAGE(this.channelID, this.id)
   }


### PR DESCRIPTION
This pull requests adds a url field for the Message structure which is a link for the message
and adds the .setCategory function for all guild channels
