### PR TITLE
Fix deno and command manager issues

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -631,9 +631,9 @@ export class CommandsManager {
 
   /** Delete a Command */
   delete(cmd: string | Command): boolean {
-    const find = typeof cmd === 'string' ? this.find(cmd) : cmd
-    if (find === undefined) return false
-    else return this.list.delete(find.name)
+    const search = this.filter(typeof cmd === 'string' ? cmd : cmd.name)
+    if (search.size === 0) return false
+    else return this.list.delete([...search.keys()][0])
   }
 
   /** Check whether a Command is disabled or not */

--- a/src/structures/channel.ts
+++ b/src/structures/channel.ts
@@ -202,7 +202,7 @@ export class GuildChannel extends Channel {
   /** Edit category of the channel */
   async setCategory(
     category: CategoryChannel | string
-  ): Promise<GuildTextBasedChannel> {
+  ): Promise<GuildChannels> {
     return await this.edit({
       parentID: typeof category === 'object' ? category.id : category
     })


### PR DESCRIPTION
## About

One of the older pull requests broke current code so this pr fixes it. There was also an issue where command manager didn't properly supplied the name.

`.add` method adds command to collection with suffix. That suffix wasn't included in the remove method.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
