### PR TITLE
FIX: TypeError `this.request` now returns `Promise<T>` and not `Promise<T | undefined>`

### DIFF
--- a/core/src/rest/http_client.ts
+++ b/core/src/rest/http_client.ts
@@ -218,6 +218,7 @@ export class HTTPClient implements HTTPClientOptions {
         }
       }
     }
+    throw new Error("Unreachable");
   }
 
   [Symbol.for("Deno.customInspect")]() {


### PR DESCRIPTION
## About

FIX: TypeError `this.request` now returns `Promise<T>` and not `Promise<T | undefined>`

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
