### PR TITLE
Add: GuildEmojiManager.fetchAll and Webhook.create

### DIFF
--- a/src/managers/guildEmojis.ts
+++ b/src/managers/guildEmojis.ts
@@ -51,19 +51,22 @@ export class GuildEmojisManager extends BaseChildManager<EmojiPayload, Emoji> {
   }
 
   async fetchAll(): Promise<Emoji[]> {
-	return await new Promise((resolve, reject) => { 
-		this.client.rest.get(GUILD_EMOJIS(this.guild.id)).then(async (data) => {
-			const emojis: Emoji[] = []
-			for (const emojiData of data as EmojiPayload[]) {
-				const emoji = new Emoji(this.client, emojiData)
-				emojiData.guild_id = this.guild.id
-				await this.set(emojiData.id!, emojiData)
-				emoji.guild = this.guild
-				emojis.push(emoji)
-			}
-			resolve(emojis)
-		}).catch((e) => reject(e))
-	})
+    return await new Promise((resolve, reject) => {
+      this.client.rest
+        .get(GUILD_EMOJIS(this.guild.id))
+        .then(async (data) => {
+          const emojis: Emoji[] = []
+          for (const emojiData of data as EmojiPayload[]) {
+            const emoji = new Emoji(this.client, emojiData)
+            emojiData.guild_id = this.guild.id
+            await this.set(emojiData.id!, emojiData)
+            emoji.guild = this.guild
+            emojis.push(emoji)
+          }
+          resolve(emojis)
+        })
+        .catch((e) => reject(e))
+    })
   }
 
   async create(

--- a/src/managers/guildEmojis.ts
+++ b/src/managers/guildEmojis.ts
@@ -50,6 +50,22 @@ export class GuildEmojisManager extends BaseChildManager<EmojiPayload, Emoji> {
     })
   }
 
+  async fetchAll(): Promise<Emoji[]> {
+	return await new Promise((resolve, reject) => { 
+		this.client.rest.get(GUILD_EMOJIS(this.guild.id)).then(async (data) => {
+			const emojis: Emoji[] = []
+			for (const emojiData of data as EmojiPayload[]) {
+				const emoji = new Emoji(this.client, emojiData)
+				emojiData.guild_id = this.guild.id
+				await this.set(emojiData.id!, emojiData)
+				emoji.guild = this.guild
+				emojis.push(emoji)
+			}
+			resolve(emojis)
+		}).catch((e) => reject(e))
+	})
+  }
+
   async create(
     name: string,
     url: string,

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -230,7 +230,7 @@ export class Webhook {
     client: Client,
     body: WebhookCreateOptions
   ): Promise<Webhook> {
-    if (typeof channel == 'object') channel = channel.id
+    if (typeof channel === 'object') channel = channel.id
     const webhook = await client.rest.post(CHANNEL_WEBHOOKS(channel), body)
     return new Webhook(webhook)
   }

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -29,10 +29,10 @@ export interface WebhookEditOptions {
 }
 
 export interface WebhookCreateOptions {
-	/** Name of the Webhook. */
-	name: string
-	/** Base64 image */
-	avatar?: string
+  /** Name of the Webhook. */
+  name: string
+  /** Base64 image */
+  avatar?: string
 }
 
 /** Webhook follows different way of instantiation */
@@ -225,9 +225,13 @@ export class Webhook {
     return this
   }
 
-  static async create(channel: string | TextChannel, client: Client, body: WebhookCreateOptions): Promise<Webhook> {
-	if (typeof channel == 'object') channel = channel.id
-	const webhook = await client.rest.post(CHANNEL_WEBHOOKS(channel), body)
-	return new Webhook(webhook)
+  static async create(
+    channel: string | TextChannel,
+    client: Client,
+    body: WebhookCreateOptions
+  ): Promise<Webhook> {
+    if (typeof channel == 'object') channel = channel.id
+    const webhook = await client.rest.post(CHANNEL_WEBHOOKS(channel), body)
+    return new Webhook(webhook)
   }
 }

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -225,9 +225,10 @@ export class Webhook {
     return this
   }
 
-  async create(channel: string | TextChannel, body: WebhookCreateOptions): Promise<Webhook> {
+  static async create(channel: string | TextChannel, body: WebhookCreateOptions, client?: Client): Promise<Webhook> {
 	if (typeof channel == 'object') channel = channel.id
-	const webhook = await this.client?.rest.post(CHANNEL_WEBHOOKS(channel), body)
+	const rest = client !== undefined ? client.rest : new RESTManager();
+	const webhook = await rest.post(CHANNEL_WEBHOOKS(channel), body)
 	return new Webhook(webhook)
   }
 }

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -8,7 +8,7 @@ import { Message, MessageAttachment } from './message.ts'
 import type { TextChannel } from './textChannel.ts'
 import { User } from './user.ts'
 import { fetchAuto } from '../../deps.ts'
-import { WEBHOOK_MESSAGE } from '../types/endpoint.ts'
+import { WEBHOOK_MESSAGE, CHANNEL_WEBHOOKS } from '../types/endpoint.ts'
 import { Constants } from '../types/constants.ts'
 
 export interface WebhookMessageOptions extends MessageOptions {
@@ -26,6 +26,13 @@ export interface WebhookEditOptions {
   avatar?: string
   /** New channel for Webhook. Requires authentication. */
   channelID?: string
+}
+
+export interface WebhookCreateOptions {
+	/** Name of the Webhook. */
+	name: string
+	/** Base64 image */
+	avatar?: string
 }
 
 /** Webhook follows different way of instantiation */
@@ -216,5 +223,11 @@ export class Webhook {
       )
     )
     return this
+  }
+
+  async create(channel: string | TextChannel, body: WebhookCreateOptions): Promise<Webhook> {
+	if (typeof channel == 'object') channel = channel.id
+	const webhook = await this.client?.rest.post(CHANNEL_WEBHOOKS(channel), body)
+	return new Webhook(webhook)
   }
 }

--- a/src/structures/webhook.ts
+++ b/src/structures/webhook.ts
@@ -225,10 +225,9 @@ export class Webhook {
     return this
   }
 
-  static async create(channel: string | TextChannel, body: WebhookCreateOptions, client?: Client): Promise<Webhook> {
+  static async create(channel: string | TextChannel, client: Client, body: WebhookCreateOptions): Promise<Webhook> {
 	if (typeof channel == 'object') channel = channel.id
-	const rest = client !== undefined ? client.rest : new RESTManager();
-	const webhook = await rest.post(CHANNEL_WEBHOOKS(channel), body)
+	const webhook = await client.rest.post(CHANNEL_WEBHOOKS(channel), body)
 	return new Webhook(webhook)
   }
 }


### PR DESCRIPTION
## About

This PR adds:
- GuildEmojiManager.fetchAll: Fetch all emotes in a server
- Webhook.create: Create a webhook in a channel 

## Status

- [X] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
