### PR TITLE
Fix: Incorrect permissions in the member object & in commands

### DIFF
--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -382,8 +382,8 @@ export class CommandClient extends Client implements CommandClientOptions {
 
         for (const perm of permissions) {
           const has =
-            msg.member?.permissions.has(perm, true) ||
-            msg.guild.ownerID === msg.author.id
+            msg.guild.ownerID === msg.author.id ||
+            msg.member?.permissions.has(perm)
           if (has !== true) missing.push(perm)
         }
 

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -381,7 +381,9 @@ export class CommandClient extends Client implements CommandClientOptions {
         const missing: string[] = []
 
         for (const perm of permissions) {
-          const has = msg.member?.permissions.has(perm)
+          const has =
+            msg.member?.permissions.has(perm, true) ||
+            msg.guild.ownerID === msg.author.id
           if (has !== true) missing.push(perm)
         }
 

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -65,7 +65,7 @@ export class Member extends SnowflakeBase {
       )
       this.permissions.add(
         ...rolePermissions.filter(
-          (p) => !this.permissions.toArray().includes(p)
+          (p) => this.permissions.toArray().includes(p) === false
         )
       )
     })

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -46,8 +46,29 @@ export class Member extends SnowflakeBase {
     this.user = user
     this.guild = guild
     this.roles = new MemberRolesManager(this.client, this.guild.roles, this)
-    if (perms !== undefined) this.permissions = perms
-    else this.permissions = new Permissions(Permissions.DEFAULT)
+    this.permissions = perms ?? new Permissions(Permissions.DEFAULT)
+    this.roles.array().then((roles) => {
+      const rolePermissions: string[] = []
+
+      for (const role of roles) {
+        rolePermissions.push(
+          ...role.permissions
+            .toArray()
+            .filter((p) => !rolePermissions.includes(p))
+        )
+      }
+
+      this.permissions.remove(
+        ...this.permissions
+          .toArray()
+          .filter((p) => !rolePermissions.includes(p))
+      )
+      this.permissions.add(
+        ...rolePermissions.filter(
+          (p) => !this.permissions.toArray().includes(p)
+        )
+      )
+    })
   }
 
   get displayName(): string {


### PR DESCRIPTION
## About

This pr fixes:
- Guild Owner getting a permission error when executing a command
- Member object always returns default permissions and doesn't include role permissions

### Note
It's possible that the perms might desync if roles get modified. Feel free to let me know where/how I should implement a fix for that.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
