### PR TITLE
feat: add audit log create event

### DIFF
--- a/src/gateway/handlers/guildAuditLogEntryCreate.ts
+++ b/src/gateway/handlers/guildAuditLogEntryCreate.ts
@@ -1,0 +1,15 @@
+import { Guild } from '../../../mod.ts'
+import { transformAuditLogEntryPayload } from '../../structures/guild.ts'
+import { GuildAuditLogEntryCreatePayload } from '../../types/gateway.ts'
+import type { Gateway, GatewayEventHandler } from '../mod.ts'
+
+export const guildAuditLogEntryCreate: GatewayEventHandler = async (
+  gateway: Gateway,
+  d: GuildAuditLogEntryCreatePayload
+) => {
+  const guild: Guild | undefined = await gateway.client.guilds.get(d.guild_id)
+  if (guild != null) {
+    const entry = transformAuditLogEntryPayload(d)
+    gateway.client.emit('guildAuditLogEntryCreate', guild, entry)
+  }
+}

--- a/src/gateway/handlers/mod.ts
+++ b/src/gateway/handlers/mod.ts
@@ -63,7 +63,7 @@ import type { Interaction } from '../../structures/interactions.ts'
 import type { CommandContext, ParsedCommand } from '../../commands/command.ts'
 import type { RequestMethods } from '../../rest/types.ts'
 import type { PartialInvitePayload } from '../../types/invite.ts'
-import type { GuildChannels } from '../../types/guild.ts'
+import type { AuditLogEntry, GuildChannels } from '../../types/guild.ts'
 import type {
   ThreadChannel,
   ThreadMember
@@ -76,6 +76,7 @@ import { threadMemberUpdate } from './threadMemberUpdate.ts'
 import { threadListSync } from './threadListSync.ts'
 import { guildStickersUpdate } from './guildStickersUpdate.ts'
 import { MessageSticker } from '../../structures/messageSticker.ts'
+import { guildAuditLogEntryCreate } from './guildAuditLogEntryCreate.ts'
 
 export const gatewayHandlers: {
   [eventCode in GatewayEvents]: GatewayEventHandler | undefined
@@ -124,7 +125,8 @@ export const gatewayHandlers: {
   THREAD_LIST_SYNC: threadListSync,
   THREAD_MEMBERS_UPDATE: threadMembersUpdate,
   THREAD_MEMBER_UPDATE: threadMemberUpdate,
-  GUILD_STICKERS_UPDATE: guildStickersUpdate
+  GUILD_STICKERS_UPDATE: guildStickersUpdate,
+  GUILD_AUDIT_LOG_ENTRY_CREATE: guildAuditLogEntryCreate
 }
 
 export interface VoiceServerUpdateData {
@@ -177,6 +179,12 @@ export type ClientEvents = {
    * @param user The User who was banned
    */
   guildBanAdd: [guild: Guild, user: User]
+  /**
+   * A new audit log entry was created
+   * @param guild The guild in which the entry was created
+   * @param entry The entry that was created
+   */
+  guildAuditLogEntryCreate: [guild: Guild, entry: AuditLogEntry]
   /**
    * A ban from a User in Guild was elevated
    * @param guild Guild from which ban was removed

--- a/src/structures/guild.ts
+++ b/src/structures/guild.ts
@@ -732,6 +732,8 @@ export class GuildIntegration extends Base {
   }
 }
 
-function transformAuditLogEntryPayload(d: AuditLogEntryPayload): AuditLogEntry {
+export function transformAuditLogEntryPayload(
+  d: AuditLogEntryPayload
+): AuditLogEntry {
   return toCamelCase(d)
 }

--- a/src/types/gateway.ts
+++ b/src/types/gateway.ts
@@ -3,7 +3,11 @@
 import type { Guild } from '../structures/guild.ts'
 import type { Member } from '../structures/member.ts'
 import type { EmojiPayload } from './emoji.ts'
-import type { GuildPayload, MemberPayload } from './guild.ts'
+import type {
+  AuditLogEntryPayload,
+  GuildPayload,
+  MemberPayload
+} from './guild.ts'
 import type {
   ActivityGame,
   ActivityPayload,
@@ -53,7 +57,9 @@ export enum GatewayCloseCodes {
 export enum GatewayIntents {
   GUILDS = 1 << 0,
   GUILD_MEMBERS = 1 << 1,
+  /** @deprecated Use GUILD_MODERATION instead */
   GUILD_BANS = 1 << 2,
+  GUILD_MODERATION = 1 << 2,
   /** @deprecated Use GUILD_EMOJIS_AND_STICKERS instead */
   GUILD_EMOJIS = 1 << 3,
   GUILD_EMOJIS_AND_STICKERS = 1 << 3,
@@ -84,6 +90,7 @@ export enum GatewayEvents {
   Guild_Delete = 'GUILD_DELETE',
   Guild_Ban_Add = 'GUILD_BAN_ADD',
   Guild_Ban_Remove = 'GUILD_BAN_REMOVE',
+  Guild_Audit_Log_Entry_Create = 'GUILD_AUDIT_LOG_ENTRY_CREATE',
   Guild_Emojis_Update = 'GUILD_EMOJIS_UPDATE',
   Guild_Stickers_Update = 'GUILD_STICKERS_UPDATE',
   Guild_Integrations_Update = 'GUILD_INTEGRATIONS_UPDATE',
@@ -196,6 +203,10 @@ export interface GuildBanAddPayload {
 export interface GuildBanRemovePayload {
   guild_id: string
   user: UserPayload
+}
+
+export interface GuildAuditLogEntryCreatePayload extends AuditLogEntryPayload {
+  guild_id: string
 }
 
 export interface GuildEmojiUpdatePayload {


### PR DESCRIPTION
## About
This pr implements [audit log create event](https://discord.com/developers/docs/change-log#guild-audit-log-events).

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.

> noticed that typings for `AuditLogEntry` were incorrect, im not really sure if i should fix them in this pr or not or if they are supposed to be like that