### PR TITLE
Add command cooldowns

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -28,7 +28,12 @@ export {
   ExtensionsManager
 } from './src/commands/extension.ts'
 export { ApplicationCommandsModule } from './src/interactions/commandModule.ts'
-export { CommandClient, command, subcommand } from './src/commands/client.ts'
+export {
+  CommandClient,
+  command,
+  subcommand,
+  CommandCooldownType
+} from './src/commands/client.ts'
 export type { CommandClientOptions } from './src/commands/client.ts'
 export { BaseManager } from './src/managers/base.ts'
 export { BaseChildManager } from './src/managers/baseChild.ts'

--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -83,9 +83,12 @@ export class CommandClient extends Client implements CommandClientOptions {
 
   middlewares = new Array<CommandContextMiddleware<CommandContext>>()
 
-  cooldown = 0;
+  cooldown = 0
 
-  private readonly lastUsed = new Map<string, { global: number, commands: { [key: string] : number } }>()
+  private readonly lastUsed = new Map<
+    string,
+    { global: number; commands: { [key: string]: number } }
+  >()
 
   constructor(options: CommandClientOptions) {
     super(options)
@@ -131,7 +134,7 @@ export class CommandClient extends Client implements CommandClientOptions {
     this.caseSensitive =
       options.caseSensitive === undefined ? false : options.caseSensitive
 
-	this.cooldown = options.cooldown ?? 0 
+    this.cooldown = options.cooldown ?? 0
 
     const self = this as any
     if (self._decoratedCommands !== undefined) {
@@ -412,16 +415,24 @@ export class CommandClient extends Client implements CommandClientOptions {
       }
     }
 
-	const userCooldowns = this.lastUsed.get(msg.author.id) ?? { global: 0, commands: {} };
-	const commandCanBeUsedAt = (userCooldowns.commands[command.name] ?? 0) + ((command.cooldown ?? 0) as number);
-	const globalCooldown = userCooldowns.global + this.cooldown;
+    const userCooldowns = this.lastUsed.get(msg.author.id) ?? {
+      global: 0,
+      commands: {}
+    }
+    const commandCanBeUsedAt =
+      (userCooldowns.commands[command.name] ?? 0) +
+      ((command.cooldown ?? 0) as number)
+    const globalCooldown = userCooldowns.global + this.cooldown
 
-	if (
-		Date.now() < commandCanBeUsedAt ||
-		Date.now() < globalCooldown
-	) {
-		return this.emit('commandOnCooldown', ctx, (commandCanBeUsedAt > globalCooldown ? commandCanBeUsedAt : globalCooldown) - Date.now());
-	}
+    if (Date.now() < commandCanBeUsedAt || Date.now() < globalCooldown) {
+      return this.emit(
+        'commandOnCooldown',
+        ctx,
+        (commandCanBeUsedAt > globalCooldown
+          ? commandCanBeUsedAt
+          : globalCooldown) - Date.now()
+      )
+    }
 
     const lastNext = async (): Promise<void> => {
       try {
@@ -431,9 +442,9 @@ export class CommandClient extends Client implements CommandClientOptions {
 
         const result = await command.execute(ctx)
         await command.afterExecute(ctx, result)
-		userCooldowns.commands[command.name] = Date.now();
-		userCooldowns.global = Date.now();
-		this.lastUsed.set(msg.author.id, userCooldowns);
+        userCooldowns.commands[command.name] = Date.now()
+        userCooldowns.global = Date.now()
+        this.lastUsed.set(msg.author.id, userCooldowns)
       } catch (e) {
         try {
           await command.onError(ctx, e as Error)

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -106,6 +106,8 @@ export class Command implements CommandOptions {
   dmOnly?: boolean
   ownerOnly?: boolean
   subCommands?: Command[]
+  /** Cooldown in MS */
+  cooldown?: number
 
   declare readonly _decoratedSubCommands?: Command[]
 

--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -108,6 +108,8 @@ export class Command implements CommandOptions {
   subCommands?: Command[]
   /** Cooldown in MS */
   cooldown?: number
+  /** Global command cooldown in MS */
+  globalCooldown?: number
 
   declare readonly _decoratedSubCommands?: Command[]
 

--- a/src/gateway/handlers/mod.ts
+++ b/src/gateway/handlers/mod.ts
@@ -452,6 +452,7 @@ export type ClientEvents = {
   commandUsed: [ctx: CommandContext]
   commandError: [ctx: CommandContext, err: Error]
   commandNotFound: [msg: Message, parsedCmd: ParsedCommand]
+  commandOnCooldown: [ctx: CommandContext, remaining: number]
   gatewayError: [err: ErrorEvent, shards: [number, number]]
   error: [error: Error]
 

--- a/src/gateway/handlers/mod.ts
+++ b/src/gateway/handlers/mod.ts
@@ -77,6 +77,7 @@ import { threadListSync } from './threadListSync.ts'
 import { guildStickersUpdate } from './guildStickersUpdate.ts'
 import { MessageSticker } from '../../structures/messageSticker.ts'
 import { guildAuditLogEntryCreate } from './guildAuditLogEntryCreate.ts'
+import { CommandCooldownType } from '../../commands/client.ts'
 
 export const gatewayHandlers: {
   [eventCode in GatewayEvents]: GatewayEventHandler | undefined
@@ -452,7 +453,11 @@ export type ClientEvents = {
   commandUsed: [ctx: CommandContext]
   commandError: [ctx: CommandContext, err: Error]
   commandNotFound: [msg: Message, parsedCmd: ParsedCommand]
-  commandOnCooldown: [ctx: CommandContext, remaining: number]
+  commandOnCooldown: [
+    ctx: CommandContext,
+    remaining: number,
+    type: CommandCooldownType
+  ]
   gatewayError: [err: ErrorEvent, shards: [number, number]]
   error: [error: Error]
 


### PR DESCRIPTION
## About

This command adds the `commandOnCooldown` event, along with a `cooldown` property on both `CommandClient` and `Command`

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
