### PR TITLE
Support 'raw' emojis

### DIFF
--- a/src/managers/messageReactions.ts
+++ b/src/managers/messageReactions.ts
@@ -82,6 +82,12 @@ export class MessageReactionsManager extends BaseManager<
 
   /** Remove a specific Emoji from Reactions */
   async removeEmoji(emoji: Emoji | string): Promise<MessageReactionsManager> {
+    emoji =
+      emoji instanceof String && emoji[0] === '<' ? emoji.substring(1) : emoji
+    emoji =
+      emoji instanceof String && emoji[emoji.length - 1] === '>'
+        ? emoji.substring(0, emoji.length - 2)
+        : emoji
     const val = encodeURIComponent(
       (typeof emoji === 'object' ? emoji.id ?? emoji.name : emoji) as string
     )
@@ -96,6 +102,13 @@ export class MessageReactionsManager extends BaseManager<
     emoji: Emoji | string,
     user: User | string
   ): Promise<MessageReactionsManager> {
+    emoji =
+      emoji instanceof String && emoji[0] === '<' ? emoji.substring(1) : emoji
+    emoji =
+      emoji instanceof String && emoji[emoji.length - 1] === '>'
+        ? emoji.substring(0, emoji.length - 2)
+        : emoji
+
     const val = encodeURIComponent(
       (typeof emoji === 'object' ? emoji.id ?? emoji.name : emoji) as string
     )

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -90,7 +90,7 @@ export class TextChannel extends Channel {
         if (findEmoji !== undefined) emoji = `${findEmoji.name}:${findEmoji.id}`
         else throw new Error(`Emoji not found: ${emoji}`)
       } else {
-        //strip out the <>
+        // strip out the <>
         emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
         emoji =
           emoji[emoji.length - 1] === '>'
@@ -120,7 +120,7 @@ export class TextChannel extends Channel {
         if (findEmoji !== undefined) emoji = `${findEmoji.name}:${findEmoji.id}`
         else throw new Error(`Emoji not found: ${emoji}`)
       } else {
-        //strip out the <>
+        // strip out the <>
         emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
         emoji =
           emoji[emoji.length - 1] === '>'

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -89,6 +89,10 @@ export class TextChannel extends Channel {
         const findEmoji = await this.client.emojis.get(emoji)
         if (findEmoji !== undefined) emoji = `${findEmoji.name}:${findEmoji.id}`
         else throw new Error(`Emoji not found: ${emoji}`)
+      } else {
+        //strip out the <>
+        emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
+        emoji = emoji[emoji.length - 1] === '>' ? emoji.substring(0, emoji.length - 2) : emoji
       }
     }
     if (message instanceof Message) message = message.id

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -116,6 +116,10 @@ export class TextChannel extends Channel {
         const findEmoji = await this.client.emojis.get(emoji)
         if (findEmoji !== undefined) emoji = `${findEmoji.name}:${findEmoji.id}`
         else throw new Error(`Emoji not found: ${emoji}`)
+      } else {
+        //strip out the <>
+        emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
+        emoji = emoji[emoji.length - 1] === '>' ? emoji.substring(0, emoji.length - 2) : emoji
       }
     }
     if (message instanceof Message) message = message.id

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -92,7 +92,10 @@ export class TextChannel extends Channel {
       } else {
         //strip out the <>
         emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
-        emoji = emoji[emoji.length - 1] === '>' ? emoji.substring(0, emoji.length - 2) : emoji
+        emoji =
+          emoji[emoji.length - 1] === '>'
+            ? emoji.substring(0, emoji.length - 2)
+            : emoji
       }
     }
     if (message instanceof Message) message = message.id
@@ -119,7 +122,10 @@ export class TextChannel extends Channel {
       } else {
         //strip out the <>
         emoji = emoji[0] === '<' ? emoji.substring(1) : emoji
-        emoji = emoji[emoji.length - 1] === '>' ? emoji.substring(0, emoji.length - 2) : emoji
+        emoji =
+          emoji[emoji.length - 1] === '>'
+            ? emoji.substring(0, emoji.length - 2)
+            : emoji
       }
     }
     if (message instanceof Message) message = message.id


### PR DESCRIPTION
## About

This pr adds option to pass emoji with enclosing `<>`, both to `<TextChannel>.addReaction` and `<TextChannel>.removeReaction`. Earlier harmony didn't said explicitly that it expects emoji strings without `<>`.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
