### PR TITLE
Add default mentions for messages

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -26,6 +26,7 @@ import { Template } from '../structures/template.ts'
 import { VoiceManager } from './voice.ts'
 import { StickersManager } from '../managers/stickers.ts'
 import { createOAuthURL, OAuthURLOptions } from '../utils/oauthURL.ts'
+import type { AllowedMentionsPayload } from '../types/channel.ts'
 
 /** OS related properties sent with Gateway Identify */
 export interface ClientProperties {
@@ -74,6 +75,8 @@ export interface ClientOptions {
   compress?: boolean
   /** Max number of messages to cache per channel. Default 100 */
   messageCacheMax?: number
+  /** Default Allowed Mentions */
+  defaultAllowedMentions?: AllowedMentionsPayload
 }
 
 /**
@@ -122,6 +125,8 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
 
   /** Client Properties */
   readonly clientProperties!: ClientProperties
+  /** Default mention settings */
+  defaultAllowedMentions: AllowedMentionsPayload = {}
 
   /** Interactions Client */
   interactions: InteractionsClient
@@ -266,6 +271,8 @@ export class Client extends HarmonyEventEmitter<ClientEvents> {
       client: this,
       enabled: options.enableSlash
     })
+
+    this.defaultAllowedMentions = options.defaultAllowedMentions ?? {}
   }
 
   /**

--- a/src/structures/textChannel.ts
+++ b/src/structures/textChannel.ts
@@ -60,7 +60,11 @@ export class TextChannel extends Channel {
     if (option instanceof Embed) {
       option = { embeds: [option] }
     }
-    return this.client.channels.sendMessage(this, content, { ...option, reply })
+    return this.client.channels.sendMessage(this, content, {
+      allowedMentions: this.client.defaultAllowedMentions,
+      ...option,
+      reply
+    })
   }
 
   /**


### PR DESCRIPTION
## About

This adds the `defaultAllowedMentions` property to `Client` so you can set default mentions to fallback on when they aren't provided. This should work similar to how libraries like discord.js do it. 

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
