### PR TITLE
Add: events for user, guild, and channel blacklist

### DIFF
--- a/src/commands/client.ts
+++ b/src/commands/client.ts
@@ -157,17 +157,6 @@ export class CommandClient extends Client implements CommandClientOptions {
   async processMessage(msg: Message): Promise<any> {
     if (!this.allowBots && msg.author.bot === true) return
 
-    const isUserBlacklisted = await this.isUserBlacklisted(msg.author.id)
-    if (isUserBlacklisted) return
-
-    const isChannelBlacklisted = await this.isChannelBlacklisted(msg.channel.id)
-    if (isChannelBlacklisted) return
-
-    if (msg.guild !== undefined) {
-      const isGuildBlacklisted = await this.isGuildBlacklisted(msg.guild.id)
-      if (isGuildBlacklisted) return
-    }
-
     let prefix: PrefixType = []
     if (typeof this.prefix === 'string' || this.prefix instanceof RegExp)
       prefix = [...prefix, this.prefix]
@@ -289,6 +278,17 @@ export class CommandClient extends Client implements CommandClientOptions {
       command,
       channel: msg.channel,
       guild: msg.guild
+    }
+
+	const isUserBlacklisted = await this.isUserBlacklisted(msg.author.id)
+    if (isUserBlacklisted) return this.emit("commandUserBlacklisted", ctx)
+
+    const isChannelBlacklisted = await this.isChannelBlacklisted(msg.channel.id)
+    if (isChannelBlacklisted) return this.emit("commandChannelBlacklisted", ctx)
+
+    if (msg.guild !== undefined) {
+      const isGuildBlacklisted = await this.isGuildBlacklisted(msg.guild.id)
+      if (isGuildBlacklisted) return this.emit("commandGuildBlacklisted", ctx)
     }
 
     // In these checks too, Command overrides Category if present

--- a/src/gateway/handlers/mod.ts
+++ b/src/gateway/handlers/mod.ts
@@ -452,6 +452,9 @@ export type ClientEvents = {
   commandUsed: [ctx: CommandContext]
   commandError: [ctx: CommandContext, err: Error]
   commandNotFound: [msg: Message, parsedCmd: ParsedCommand]
+  commandUserBlacklisted: [ctx: CommandContext]
+  commandGuildBlacklisted: [ctx: CommandContext]
+  commandChannelBlacklisted: [ctx: CommandContext]
   gatewayError: [err: ErrorEvent, shards: [number, number]]
   error: [error: Error]
 


### PR DESCRIPTION
## About
This pr adds the events `commandUserBlacklisted`, `commandChannelBlacklisted`, and `commandGuildBlacklisted` that execute when a blacklist occurs. 
I moved the checks after `ctx` is defined so that it could be passed and from my testing it looks to not have broken anything but if there's any issues please let me know. 

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
