### PR TITLE
Fix: Prevent invalid color codes from being generated

### DIFF
--- a/src/utils/colorutil.ts
+++ b/src/utils/colorutil.ts
@@ -235,7 +235,7 @@ export class ColorUtil {
 
   /** Returns random hex code */
   static randomHex(): string {
-    const code = `#${Math.floor(Math.random() * (0xffffff + 1)).toString(16)}`
+    const code = `#${Math.floor(Math.random() * (0xffffff + 1)).toString(16).padStart(6, '0')}`
     if (!ColorUtil.isHex(code)) return '#000000'
     return code
   }

--- a/src/utils/colorutil.ts
+++ b/src/utils/colorutil.ts
@@ -235,7 +235,9 @@ export class ColorUtil {
 
   /** Returns random hex code */
   static randomHex(): string {
-    const code = `#${Math.floor(Math.random() * (0xffffff + 1)).toString(16).padStart(6, '0')}`
+    const code = `#${Math.floor(Math.random() * (0xffffff + 1))
+      .toString(16)
+      .padStart(6, '0')}`
     if (!ColorUtil.isHex(code)) return '#000000'
     return code
   }


### PR DESCRIPTION
## About
This fix makes the random hex method no longer sometimes return an invalid color code due to generating an invalid length hex code.  

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
