### PR TITLE
Feat: Display name support

### DIFF
--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -77,7 +77,9 @@ export class Member extends SnowflakeBase {
   }
 
   get displayName(): string {
-    return this.nick !== null ? this.nick : this.user.displayName ?? this.user.username
+    return this.nick !== null
+      ? this.nick
+      : this.user.displayName ?? this.user.username
   }
 
   toString(): string {

--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -77,7 +77,7 @@ export class Member extends SnowflakeBase {
   }
 
   get displayName(): string {
-    return this.nick !== null ? this.nick : this.user.username
+    return this.nick !== null ? this.nick : this.user.displayName ?? this.user.username
   }
 
   toString(): string {

--- a/src/structures/user.ts
+++ b/src/structures/user.ts
@@ -34,7 +34,9 @@ export class User extends SnowflakeBase {
   publicFlags!: UserFlagsManager
 
   get tag(): string {
-    return this.discriminator === "0" ? this.displayName : `${this.username}#${this.discriminator}`
+    return this.discriminator === '0'
+      ? this.displayName
+      : `${this.username}#${this.discriminator}`
   }
 
   get nickMention(): string {
@@ -63,7 +65,7 @@ export class User extends SnowflakeBase {
 
   readFromData(data: UserPayload): void {
     this.username = data.username ?? this.username
-	this.displayName = data.global_name ?? this.displayName ?? this.username
+    this.displayName = data.global_name ?? this.displayName ?? this.username
     this.discriminator = data.discriminator ?? this.discriminator
     this.avatar = data.avatar ?? this.avatar
     this.bot = data.bot ?? this.bot

--- a/src/structures/user.ts
+++ b/src/structures/user.ts
@@ -13,6 +13,7 @@ import { IResolvable } from './resolvable.ts'
 export class User extends SnowflakeBase {
   id: string
   username!: string
+  displayName!: string
   discriminator!: string
   avatar?: string
   bot?: boolean
@@ -33,7 +34,7 @@ export class User extends SnowflakeBase {
   publicFlags!: UserFlagsManager
 
   get tag(): string {
-    return `${this.username}#${this.discriminator}`
+    return this.discriminator === "0" ? this.displayName : `${this.username}#${this.discriminator}`
   }
 
   get nickMention(): string {
@@ -62,6 +63,7 @@ export class User extends SnowflakeBase {
 
   readFromData(data: UserPayload): void {
     this.username = data.username ?? this.username
+	this.displayName = data.global_name ?? this.displayName ?? this.username
     this.discriminator = data.discriminator ?? this.discriminator
     this.avatar = data.avatar ?? this.avatar
     this.bot = data.bot ?? this.bot

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,6 +1,7 @@
 export interface UserPayload {
   id: string
   username: string
+  global_name?: string
   discriminator: string
   avatar?: string
   bot?: boolean


### PR DESCRIPTION
## About
This adds discord's display name property to the user class and also changes `tag` to return their "handle" if they don't have a discriminator

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
