### PR TITLE
Fix voice state update sometimes not setting the member cache

### DIFF
--- a/src/gateway/handlers/voiceStateUpdate.ts
+++ b/src/gateway/handlers/voiceStateUpdate.ts
@@ -14,10 +14,11 @@ export const voiceStateUpdate: GatewayEventHandler = async (
   )) as unknown as Guild
 
   const voiceState = await guild.voiceStates.get(d.user_id)
+  
+  await guild.members.set(d.user_id, d.member as unknown as MemberPayload)
 
   if (d.channel_id === null) {
     if (voiceState === undefined) {
-      await guild.members.set(d.user_id, d.member as unknown as MemberPayload)
       const member = (await guild.members.get(
         d.user_id
       )) as unknown as MemberPayload

--- a/src/gateway/handlers/voiceStateUpdate.ts
+++ b/src/gateway/handlers/voiceStateUpdate.ts
@@ -14,7 +14,7 @@ export const voiceStateUpdate: GatewayEventHandler = async (
   )) as unknown as Guild
 
   const voiceState = await guild.voiceStates.get(d.user_id)
-  
+
   await guild.members.set(d.user_id, d.member as unknown as MemberPayload)
 
   if (d.channel_id === null) {


### PR DESCRIPTION
## About

Fixes a bug where voice state update events didn't always set the member cache, leading to the `user` and `member` properties on `VoiceState` objects being missing.

## Status

- [X] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
