### PR TITLE
Fix: Error thrown from channel mention in webhook

### DIFF
--- a/src/structures/messageMentions.ts
+++ b/src/structures/messageMentions.ts
@@ -51,6 +51,9 @@ export class MessageMentions {
     if (matchChannels !== null) {
       for (const id of matchChannels) {
         const parsedID = id.substr(2, id.length - 3)
+
+        if (this.client === undefined) continue
+
         const channel = await this.client.channels.get<GuildTextBasedChannel>(
           parsedID
         )


### PR DESCRIPTION
## About

Closes #370 

Skips fetching channel info if `this.client` is undefined as is the case in a webhook message thus not causing a crash

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
