### PR TITLE
Feat: Extension directory loading

### DIFF
--- a/src/commands/command.ts
+++ b/src/commands/command.ts
@@ -428,7 +428,6 @@ export class CommandsLoader {
   async loadDirectory(
     path: string,
     options?: {
-      recursive?: boolean
       exportName?: string
       maxDepth?: number
       exts?: string[]


### PR DESCRIPTION
## About

Closes #137

Adds a `loadDirectory` method on the `ExtensionManager` thus allowing loading similar to the way you can with commands.

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
