### PR TITLE
Fix: Server Owner perms are reported wrong

### DIFF
--- a/src/structures/member.ts
+++ b/src/structures/member.ts
@@ -46,7 +46,10 @@ export class Member extends SnowflakeBase {
     this.user = user
     this.guild = guild
     this.roles = new MemberRolesManager(this.client, this.guild.roles, this)
-    this.permissions = perms ?? new Permissions(Permissions.DEFAULT)
+    this.permissions =
+      this.guild.ownerID === this.id
+        ? new Permissions(Permissions.ALL)
+        : perms ?? new Permissions(Permissions.DEFAULT)
     this.roles
       .array()
       .then((roles) => {


### PR DESCRIPTION
## About

This PR makes server owners have all permissions by default as currently checking for items such as admin would return false even though the owner would have it.

Possibly fixes #369? I'm not 100% sure if this is what was meant given my testing seems to show all users correctly other than owner

## Status

- [x] These changes have been tested against Discord API or do not contain API change.
- [ ] This PR includes only documentation changes, no code change.
- [ ] This PR introduces some Breaking changes.
